### PR TITLE
Pr/parametrize text encoder tokenizer

### DIFF
--- a/src/refiners/foundationals/clip/text_encoder.py
+++ b/src/refiners/foundationals/clip/text_encoder.py
@@ -25,7 +25,7 @@ class PositionalTokenEncoder(Sum):
         positional_embedding_dim: int,
         device: Device | str | None = None,
         dtype: DType | None = None,
-    ):
+    ) -> None:
         self.vocabulary_size = vocabulary_size
         self.positional_embedding_dim = positional_embedding_dim
         super().__init__(
@@ -36,7 +36,7 @@ class PositionalTokenEncoder(Sum):
                 dtype=dtype,
             ),
             Chain(
-                Lambda(self.get_position_ids),
+                Lambda(func=self.get_position_ids),
                 Embedding(
                     num_embeddings=positional_embedding_dim,
                     embedding_dim=embedding_dim,
@@ -48,7 +48,7 @@ class PositionalTokenEncoder(Sum):
 
     @property
     def position_ids(self) -> Tensor:
-        return arange(self.positional_embedding_dim, device=self.device).reshape(1, -1)
+        return arange(end=self.positional_embedding_dim, device=self.device).reshape(1, -1)
 
     def get_position_ids(self, x: Tensor) -> Tensor:
         return self.position_ids[:, : x.shape[1]]
@@ -145,7 +145,7 @@ class CLIPTextEncoder(Chain):
         layer_norm_eps: float = 1e-5,
         device: Device | str | None = None,
         dtype: DType | None = None,
-    ):
+    ) -> None:
         self.embedding_dim = embedding_dim
         self.positional_embedding_dim = positional_embedding_dim
         self.vocabulary_size = vocabulary_size
@@ -177,12 +177,12 @@ class CLIPTextEncoder(Chain):
         )
 
     def encode(self, text: str) -> Tensor:
-        tokens = self.tokenizer(text, sequence_length=self.positional_embedding_dim).to(self.device)
+        tokens = self.tokenizer(text, sequence_length=self.positional_embedding_dim).to(device=self.device)
         return self(tokens)
 
     @property
     def unconditional_text_embedding(self) -> Tensor:
-        return self.encode("")
+        return self.encode(text="")
 
 
 class CLIPTextEncoderL(CLIPTextEncoder):
@@ -206,7 +206,7 @@ class CLIPTextEncoderL(CLIPTextEncoder):
             device=device,
             dtype=dtype,
         )
-        for gelu, parent in self.walk(lambda m, _: isinstance(m, GeLU)):
+        for gelu, parent in self.walk(predicate=lambda m, _: isinstance(m, GeLU)):
             parent.replace(old_module=gelu, new_module=ApproximateGeLU())
 
 

--- a/src/refiners/foundationals/clip/text_encoder.py
+++ b/src/refiners/foundationals/clip/text_encoder.py
@@ -145,6 +145,7 @@ class CLIPTextEncoder(Chain):
         feedforward_dim: int = 3072,
         layer_norm_eps: float = 1e-5,
         use_quick_gelu: bool = False,
+        tokenizer: CLIPTokenizer | None = None,
         device: Device | str | None = None,
         dtype: DType | None = None,
     ) -> None:
@@ -156,7 +157,7 @@ class CLIPTextEncoder(Chain):
         self.feedforward_dim = feedforward_dim
         self.layer_norm_eps = layer_norm_eps
         self.use_quick_gelu = use_quick_gelu
-        self.tokenizer = CLIPTokenizer()
+        self.tokenizer = tokenizer or CLIPTokenizer()
         super().__init__(
             PositionalTokenEncoder(
                 vocabulary_size=vocabulary_size,

--- a/src/refiners/foundationals/clip/text_encoder.py
+++ b/src/refiners/foundationals/clip/text_encoder.py
@@ -247,11 +247,14 @@ class CLIPTextEncoderG(CLIPTextEncoder):
     """
 
     def __init__(self, device: Device | str | None = None, dtype: DType | None = None) -> None:
+        tokenizer = CLIPTokenizer(pad_token_id=0)
         super().__init__(
             embedding_dim=1280,
             num_layers=32,
             num_attention_heads=20,
             feedforward_dim=5120,
+            use_quick_gelu=True,
+            tokenizer=tokenizer,
             device=device,
             dtype=dtype,
         )

--- a/src/refiners/foundationals/clip/tokenizer.py
+++ b/src/refiners/foundationals/clip/tokenizer.py
@@ -11,6 +11,9 @@ class CLIPTokenizer:
     def __init__(
         self,
         vocabulary_path: str | Path = Path(__file__).resolve().parent / "bpe_simple_vocab_16e6.txt.gz",
+        start_of_text_token_id: int = 49406,
+        end_of_text_token_id: int = 49407,
+        pad_token_id: int = 49407,
     ) -> None:
         self.vocabulary_path = vocabulary_path
         self.byte_to_unicode_mapping = self.get_bytes_to_unicode_mapping()
@@ -38,15 +41,16 @@ class CLIPTokenizer:
             pattern=r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[a-zA-Z]+|[0-9]|[^\s\w]+""",
             flags=re.IGNORECASE,
         )
-        self.start_of_text_token_id: int = 49406
-        self.end_of_text_token_id: int = 49407
+        self.start_of_text_token_id: int = start_of_text_token_id
+        self.end_of_text_token_id: int = end_of_text_token_id
+        self.pad_token_id: int = pad_token_id
 
     def __call__(self, text: str, sequence_length: int) -> Tensor:
         tokens = self.encode(text=text, max_length=sequence_length).unsqueeze(dim=0)
         assert (
             tokens.shape[1] <= sequence_length
         ), f"Text is too long: tokens.shape[1] > sequence_length: {tokens.shape[1]} > {sequence_length}"
-        return pad(x=tokens, pad=(0, sequence_length - tokens.shape[1]), value=self.end_of_text_token_id)
+        return pad(x=tokens, pad=(0, sequence_length - tokens.shape[1]), value=self.pad_token_id)
 
     @lru_cache()
     def get_bytes_to_unicode_mapping(self) -> dict[int, str]:


### PR DESCRIPTION
Currently, there is no way to specify or parametrize the tokenizer a CLIPTextEncoder should use. 

This is useful for OpenCLIP's CLIPTextEncoderG that uses a pad_token_id of 0.