### PR TITLE
Turn CLIPTokenizer Into a fl.Module

### DIFF
--- a/scripts/convert-clip-weights.py
+++ b/scripts/convert-clip-weights.py
@@ -6,13 +6,16 @@ from diffusers import DiffusionPipeline  # type: ignore
 from transformers.models.clip.modeling_clip import CLIPTextModel  # type: ignore
 
 from refiners.foundationals.clip.text_encoder import CLIPTextEncoderL
+from refiners.foundationals.clip.tokenizer import CLIPTokenizer
 
 
 @torch.no_grad()
 def convert(src_model: CLIPTextModel) -> dict[str, torch.Tensor]:
     dst_model = CLIPTextEncoderL()
-    x = dst_model.tokenizer("Nice cat", sequence_length=77)
-    mapping = create_state_dict_mapping(source_model=src_model, target_model=dst_model, source_args=[x])  # type: ignore
+    tokenizer = dst_model.find(layer_type=CLIPTokenizer)
+    assert tokenizer is not None, "Could not find tokenizer"
+    tokens = tokenizer("Nice cat")
+    mapping = create_state_dict_mapping(source_model=src_model, target_model=dst_model, source_args=[tokens], target_args=["Nice cat"])  # type: ignore
     assert mapping is not None, "Model conversion failed"
     state_dict = convert_state_dict(
         source_state_dict=src_model.state_dict(), target_state_dict=dst_model.state_dict(), state_dict_mapping=mapping

--- a/scripts/convert-loras-to-sdwebui.py
+++ b/scripts/convert-loras-to-sdwebui.py
@@ -4,6 +4,7 @@ from refiners.fluxion.utils import (
     save_to_safetensors,
 )
 from refiners.foundationals.clip.text_encoder import CLIPTextEncoderL
+from refiners.foundationals.clip.tokenizer import CLIPTokenizer
 from refiners.foundationals.latent_diffusion.unet import UNet
 from refiners.foundationals.latent_diffusion.lora import LoraTarget
 from refiners.fluxion.layers.module import Module
@@ -33,9 +34,10 @@ def create_unet_mapping(src_model: UNet2DConditionModel, dst_model: UNet) -> dic
 
 @torch.no_grad()
 def create_text_encoder_mapping(src_model: CLIPTextModel, dst_model: CLIPTextEncoderL) -> dict[str, str] | None:
-    x = dst_model.tokenizer("Nice cat", sequence_length=77)
-
-    return create_state_dict_mapping(source_model=src_model, target_model=dst_model, source_args=[x])  # type: ignore
+    tokenizer = dst_model.find(layer_type=CLIPTokenizer)
+    assert tokenizer is not None, "Could not find tokenizer"
+    tokens = tokenizer("Nice cat")
+    return create_state_dict_mapping(source_model=src_model, target_model=dst_model, source_args=[tokens], target_args=["Nice cat"])  # type: ignore
 
 
 def main() -> None:

--- a/src/refiners/foundationals/latent_diffusion/__init__.py
+++ b/src/refiners/foundationals/latent_diffusion/__init__.py
@@ -88,7 +88,7 @@ class LatentDiffusionModel(Module):
         return self.clip_text_encoder.unconditional_text_embedding
 
     def compute_text_embedding(self, text: str) -> Tensor:
-        return self.clip_text_encoder.encode(text)
+        return self.clip_text_encoder(text)
 
     def forward(
         self,

--- a/src/refiners/training_utils/latent_diffusion.py
+++ b/src/refiners/training_utils/latent_diffusion.py
@@ -89,7 +89,7 @@ class TextEmbeddingLatentsDataset(Dataset[TextEmbeddingLatentsBatch]):
         processed_image: Image.Image = self.process_image(resized_image)
         latents = self.lda.encode_image(image=processed_image).to(device=self.device)
         processed_caption = self.process_caption(caption=caption)
-        clip_text_embedding = self.text_encoder.encode(text=processed_caption).to(device=self.device)
+        clip_text_embedding = self.text_encoder(processed_caption).to(device=self.device)
         return TextEmbeddingLatentsBatch(text_embeddings=clip_text_embedding, latents=latents)
 
     def collate_fn(self, batch: list[TextEmbeddingLatentsBatch]) -> TextEmbeddingLatentsBatch:

--- a/tests/foundationals/clip/test_text_encoder.py
+++ b/tests/foundationals/clip/test_text_encoder.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from refiners.foundationals.clip.text_encoder import CLIPTextEncoderL
 from refiners.fluxion.utils import load_from_safetensors
 
-import transformers  # type: ignore
+import transformers # type: ignore
+from refiners.foundationals.clip.tokenizer import CLIPTokenizer
 
 
 long_prompt = """
@@ -86,12 +87,14 @@ def test_encoder(
         return_tensors="pt",
     ).input_ids
     assert isinstance(ref_tokens, torch.Tensor)
-    our_tokens = our_encoder.tokenizer(prompt, sequence_length=our_encoder.max_sequence_length)
+    tokenizer = our_encoder.find(layer_type=CLIPTokenizer)
+    assert tokenizer is not None
+    our_tokens = tokenizer(prompt)
     assert torch.equal(our_tokens, ref_tokens)
 
     with torch.no_grad():
         ref_embeddings = ref_encoder(ref_tokens.to(test_device))[0]
-        our_embeddings = our_encoder(our_tokens.to(test_device))
+        our_embeddings = our_encoder(prompt)
 
     assert ref_embeddings.shape == (1, 77, 768)
     assert our_embeddings.shape == (1, 77, 768)


### PR DESCRIPTION
Currently Tokenizer is just a basic object which means it cannot be a part of a Chain or be targeted by Adapters. 

  * Turn Tokenizer into a fl.Module
  * Change the API of the CLIPTextEncoder (which now take as input a text instead of tokens)