### PR TITLE
Make horizontal flipping parametrable in training scripts

### DIFF
--- a/src/refiners/training_utils/config.py
+++ b/src/refiners/training_utils/config.py
@@ -208,6 +208,8 @@ class HuggingfaceDatasetConfig(BaseModel):
     hf_repo: str = "finegrain/unsplash-dummy"
     revision: str = "main"
     split: str = "train"
+    horizontal_flip: bool = False
+    random_crop: bool = True
     use_verification: bool = False
 
 


### PR DESCRIPTION
- Replaces the existing process_image in LatentDiffusionConfig with a more flexible and configurable approach using Compose.
- Adds support for horizontal flipping as part of the image processing.
- Allows the random crop transform to be toggled on or off.