### PR TITLE
foundationals: add clip image encoder

### DIFF
--- a/scripts/conversion/convert_transformers_clip_image_model.py
+++ b/scripts/conversion/convert_transformers_clip_image_model.py
@@ -1,0 +1,137 @@
+import argparse
+from pathlib import Path
+from torch import nn
+from refiners.fluxion.model_converter import ModelConverter
+from transformers import CLIPVisionModelWithProjection  # type: ignore
+from refiners.foundationals.clip.image_encoder import CLIPImageEncoder
+from refiners.fluxion.utils import save_to_safetensors
+import torch
+import refiners.fluxion.layers as fl
+
+
+class Args(argparse.Namespace):
+    source_path: str
+    subfolder: str
+    output_path: str | None
+    half: bool
+    verbose: bool
+
+
+def setup_converter(args: Args) -> ModelConverter:
+    source: nn.Module = CLIPVisionModelWithProjection.from_pretrained(  # type: ignore
+        pretrained_model_name_or_path=args.source_path, subfolder=args.subfolder
+    )
+    assert isinstance(source, nn.Module), "Source model is not a nn.Module"
+    architecture: str = source.config.architectures[0]  # type: ignore
+    num_channels: int = source.config.num_channels  # type: ignore
+    embedding_dim: int = source.config.hidden_size  # type: ignore
+    image_size: int = source.config.image_size  # type: ignore
+    patch_size: int = source.config.patch_size  # type: ignore
+    output_dim: int = source.config.projection_dim  # type: ignore
+    num_layers: int = source.config.num_hidden_layers  # type: ignore
+    num_attention_heads: int = source.config.num_attention_heads  # type: ignore
+    feedforward_dim: int = source.config.intermediate_size  # type: ignore
+    activation: str = source.config.hidden_act  # type: ignore
+    layer_norm_eps: float = source.config.layer_norm_eps  # type: ignore
+
+    assert architecture == "CLIPVisionModelWithProjection", f"Unsupported architecture: {architecture}"
+    assert num_channels == 3, f"Expected 3 input channels, got {num_channels}"
+    assert activation == "gelu", f"Unsupported activation: {activation}"
+
+    target = CLIPImageEncoder(
+        image_size=image_size,
+        embedding_dim=embedding_dim,
+        output_dim=output_dim,
+        patch_size=patch_size,
+        num_layers=num_layers,
+        num_attention_heads=num_attention_heads,
+        feedforward_dim=feedforward_dim,
+        layer_norm_eps=layer_norm_eps,
+    )
+
+    x = torch.randn(1, 3, image_size, image_size)
+
+    converter = ModelConverter(source_model=source, target_model=target, verbose=True)
+
+    # Custom conversion logic since the class embedding (fl.Parameter layer) is not supported out-of-the-box by the
+    # converter
+    mapping = converter.map_state_dicts((x,))
+    assert mapping is not None
+
+    source_state_dict = source.state_dict()
+    target_state_dict = target.state_dict()
+
+    # Remove the class embedding from state dict since it was not mapped by the model converter
+    class_embedding = target.find(fl.Parameter)
+    assert class_embedding is not None
+    class_embedding_key = next(
+        (n for n, p in target.named_parameters() if id(p) == id(class_embedding.parameter)), None
+    )
+    assert class_embedding_key is not None
+    assert class_embedding_key in target_state_dict
+    del target_state_dict[class_embedding_key]
+
+    converted_state_dict = converter._convert_state_dict(  # type: ignore[reportPrivateUsage]
+        source_state_dict=source_state_dict, target_state_dict=target_state_dict, state_dict_mapping=mapping
+    )
+    target.load_state_dict(state_dict=converted_state_dict, strict=False)
+
+    # Ad hoc post-conversion steps
+    class_embedding.parameter = torch.nn.Parameter(source.vision_model.embeddings.class_embedding.clone())  # type: ignore
+
+    assert converter.compare_models((x,), threshold=1e-2)
+
+    return converter
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Converts a CLIPImageEncoder from the library transformers from the HuggingFace Hub to refiners."
+    )
+    parser.add_argument(
+        "--from",
+        type=str,
+        dest="source_path",
+        default="stabilityai/stable-diffusion-2-1-unclip",
+        help=(
+            "Can be a path to a .bin file, a .safetensors file or a model name from the HuggingFace Hub. Default:"
+            " stabilityai/stable-diffusion-2-1-unclip"
+        ),
+    )
+    parser.add_argument(
+        "--subfolder",
+        type=str,
+        dest="subfolder",
+        default="image_encoder",
+        help="Subfolder in the source path where the model is located inside the Hub. Default: image_encoder",
+    )
+    parser.add_argument(
+        "--to",
+        type=str,
+        dest="output_path",
+        default=None,
+        help=(
+            "Output path (.safetensors) for converted model. If not provided, the output path will be the same as the"
+            " source path."
+        ),
+    )
+    parser.add_argument("--half", action="store_true", default=True, help="Convert to half precision. Default: True")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Prints additional information during conversion. Default: False",
+    )
+    args = parser.parse_args(namespace=Args())
+    if args.output_path is None:
+        args.output_path = f"{Path(args.source_path).stem}-{args.subfolder}.safetensors"
+    converter = setup_converter(args=args)
+    # Do not use converter.save_to_safetensors since it is not in a valid state due to the ad hoc conversion
+    state_dict = converter.target_model.state_dict()
+    if args.half:
+        state_dict = {key: value.half() for key, value in state_dict.items()}
+    save_to_safetensors(path=args.output_path, tensors=state_dict)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conversion/convert_transformers_clip_text_model.py
+++ b/scripts/conversion/convert_transformers_clip_text_model.py
@@ -12,7 +12,7 @@ class Args(argparse.Namespace):
     source_path: str
     subfolder: str
     output_path: str | None
-    use_half: bool
+    half: bool
     verbose: bool
 
 

--- a/src/refiners/foundationals/clip/common.py
+++ b/src/refiners/foundationals/clip/common.py
@@ -1,0 +1,51 @@
+from torch import Tensor, arange, device as Device, dtype as DType
+import refiners.fluxion.layers as fl
+
+
+class PositionalEncoder(fl.Chain):
+    structural_attrs = ["max_sequence_length", "embedding_dim"]
+
+    def __init__(
+        self,
+        max_sequence_length: int,
+        embedding_dim: int,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.max_sequence_length = max_sequence_length
+        self.embedding_dim = embedding_dim
+        super().__init__(
+            fl.Lambda(func=self.get_position_ids),
+            fl.Embedding(
+                num_embeddings=max_sequence_length,
+                embedding_dim=embedding_dim,
+                device=device,
+                dtype=dtype,
+            ),
+        )
+
+    @property
+    def position_ids(self) -> Tensor:
+        return arange(end=self.max_sequence_length, device=self.device).reshape(1, -1)
+
+    def get_position_ids(self, x: Tensor) -> Tensor:
+        return self.position_ids[:, : x.shape[1]]
+
+
+class FeedForward(fl.Chain):
+    structural_attrs = ["embedding_dim", "feedforward_dim"]
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        feedforward_dim: int,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.embedding_dim = embedding_dim
+        self.feedforward_dim = feedforward_dim
+        super().__init__(
+            fl.Linear(in_features=embedding_dim, out_features=feedforward_dim, device=device, dtype=dtype),
+            fl.GeLU(),
+            fl.Linear(in_features=feedforward_dim, out_features=embedding_dim, device=device, dtype=dtype),
+        )

--- a/src/refiners/foundationals/clip/image_encoder.py
+++ b/src/refiners/foundationals/clip/image_encoder.py
@@ -1,0 +1,182 @@
+from torch import device as Device, dtype as DType
+import refiners.fluxion.layers as fl
+from refiners.foundationals.clip.common import PositionalEncoder, FeedForward
+
+
+class ClassEncoder(fl.Chain):
+    structural_attrs = ["embedding_dim"]
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.embedding_dim = embedding_dim
+        super().__init__(
+            fl.Parallel(fl.Identity(), fl.Parameter(embedding_dim, device=device, dtype=dtype)),
+            fl.Lambda(lambda x, p: p.expand(x.shape[0], 1, -1)),
+        )
+
+
+class PatchEncoder(fl.Chain):
+    structural_attrs = ["in_channels", "out_channels", "patch_size", "use_bias"]
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        patch_size: int = 16,
+        use_bias: bool = True,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.patch_size = patch_size
+        self.use_bias = use_bias
+        super().__init__(
+            fl.Conv2d(
+                in_channels=self.in_channels,
+                out_channels=self.out_channels,
+                kernel_size=(self.patch_size, self.patch_size),
+                stride=(self.patch_size, self.patch_size),
+                use_bias=self.use_bias,
+                device=device,
+                dtype=dtype,
+            ),
+            fl.Permute(0, 2, 3, 1),
+        )
+
+
+class TransformerLayer(fl.Chain):
+    structural_attrs = ["embedding_dim", "feedforward_dim", "num_attention_heads", "layer_norm_eps"]
+
+    def __init__(
+        self,
+        embedding_dim: int = 768,
+        feedforward_dim: int = 3072,
+        num_attention_heads: int = 12,
+        layer_norm_eps: float = 1e-5,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.embedding_dim = embedding_dim
+        self.feedforward_dim = feedforward_dim
+        self.num_attention_heads = num_attention_heads
+        self.layer_norm_eps = layer_norm_eps
+        super().__init__(
+            fl.Residual(
+                fl.LayerNorm(normalized_shape=embedding_dim, eps=layer_norm_eps, device=device, dtype=dtype),
+                fl.SelfAttention(
+                    embedding_dim=embedding_dim, num_heads=num_attention_heads, device=device, dtype=dtype
+                ),
+            ),
+            fl.Residual(
+                fl.LayerNorm(normalized_shape=embedding_dim, eps=layer_norm_eps, device=device, dtype=dtype),
+                FeedForward(embedding_dim=embedding_dim, feedforward_dim=feedforward_dim, device=device, dtype=dtype),
+            ),
+        )
+
+
+class ViTEmbeddings(fl.Chain):
+    structural_attrs = ["image_size", "embedding_dim", "patch_size"]
+
+    def __init__(
+        self,
+        image_size: int = 224,
+        embedding_dim: int = 768,
+        patch_size: int = 32,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        super().__init__(
+            fl.Concatenate(
+                ClassEncoder(embedding_dim=embedding_dim, device=device, dtype=dtype),
+                fl.Chain(
+                    PatchEncoder(
+                        in_channels=3,
+                        out_channels=embedding_dim,
+                        patch_size=patch_size,
+                        use_bias=False,
+                        device=device,
+                        dtype=dtype,
+                    ),
+                    fl.Reshape((image_size // patch_size) ** 2, embedding_dim),
+                ),
+                dim=1,
+            ),
+            fl.Residual(
+                PositionalEncoder(
+                    max_sequence_length=(image_size // patch_size) ** 2 + 1,
+                    embedding_dim=embedding_dim,
+                    device=device,
+                    dtype=dtype,
+                ),
+            ),
+        )
+
+
+class CLIPImageEncoder(fl.Chain):
+    structural_attrs = [
+        "image_size",
+        "embedding_dim",
+        "patch_size",
+        "num_layers",
+        "num_attention_heads",
+        "feedforward_dim",
+    ]
+
+    def __init__(
+        self,
+        image_size: int = 224,
+        embedding_dim: int = 768,
+        output_dim: int = 512,
+        patch_size: int = 32,
+        num_layers: int = 12,
+        num_attention_heads: int = 12,
+        feedforward_dim: int = 3072,
+        layer_norm_eps: float = 1e-5,
+        device: Device | str | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        self.image_size = image_size
+        self.embedding_dim = embedding_dim
+        self.patch_size = patch_size
+        self.num_layers = num_layers
+        self.num_attention_heads = num_attention_heads
+        self.feedforward_dim = feedforward_dim
+        super().__init__(
+            ViTEmbeddings(
+                image_size=image_size, embedding_dim=embedding_dim, patch_size=patch_size, device=device, dtype=dtype
+            ),
+            fl.LayerNorm(normalized_shape=embedding_dim, eps=layer_norm_eps, device=device, dtype=dtype),
+            fl.Chain(
+                TransformerLayer(
+                    embedding_dim=embedding_dim,
+                    feedforward_dim=feedforward_dim,
+                    num_attention_heads=num_attention_heads,
+                    layer_norm_eps=layer_norm_eps,
+                    device=device,
+                    dtype=dtype,
+                )
+                for _ in range(num_layers)
+            ),
+            fl.Lambda(func=lambda x: x[:, 0, :]),
+            fl.LayerNorm(normalized_shape=embedding_dim, eps=layer_norm_eps, device=device, dtype=dtype),
+            fl.Linear(in_features=embedding_dim, out_features=output_dim, bias=False, device=device, dtype=dtype),
+        )
+
+
+class CLIPImageEncoderH(CLIPImageEncoder):
+    def __init__(self, device: Device | str | None = None, dtype: DType | None = None) -> None:
+        super().__init__(
+            embedding_dim=1280,
+            output_dim=1024,
+            patch_size=14,
+            num_layers=32,
+            num_attention_heads=16,
+            feedforward_dim=5120,
+            device=device,
+            dtype=dtype,
+        )

--- a/src/refiners/foundationals/clip/text_encoder.py
+++ b/src/refiners/foundationals/clip/text_encoder.py
@@ -1,5 +1,6 @@
-from torch import Tensor, arange, device as Device, dtype as DType
+from torch import device as Device, dtype as DType
 import refiners.fluxion.layers as fl
+from refiners.foundationals.clip.common import PositionalEncoder, FeedForward
 from refiners.foundationals.clip.tokenizer import CLIPTokenizer
 
 
@@ -20,55 +21,6 @@ class TokenEncoder(fl.Embedding):
             embedding_dim=embedding_dim,
             device=device,
             dtype=dtype,
-        )
-
-
-class PositionalEncoder(fl.Chain):
-    structural_attrs = ["max_sequence_length", "embedding_dim"]
-
-    def __init__(
-        self,
-        max_sequence_length: int,
-        embedding_dim: int,
-        device: Device | str | None = None,
-        dtype: DType | None = None,
-    ) -> None:
-        self.max_sequence_length = max_sequence_length
-        self.embedding_dim = embedding_dim
-        super().__init__(
-            fl.Lambda(func=self.get_position_ids),
-            fl.Embedding(
-                num_embeddings=max_sequence_length,
-                embedding_dim=embedding_dim,
-                device=device,
-                dtype=dtype,
-            ),
-        )
-
-    @property
-    def position_ids(self) -> Tensor:
-        return arange(end=self.max_sequence_length, device=self.device).reshape(1, -1)
-
-    def get_position_ids(self, x: Tensor) -> Tensor:
-        return self.position_ids[:, : x.shape[1]]
-
-
-class FeedForward(fl.Chain):
-    structural_attrs = ["embedding_dim", "feedforward_dim"]
-
-    def __init__(
-        self,
-        embedding_dim: int,
-        feedforward_dim: int,
-        device: Device | str | None = None,
-        dtype: DType | None = None,
-    ) -> None:
-        self.embedding_dim = embedding_dim
-        self.feedforward_dim = feedforward_dim
-        super().__init__(
-            fl.Linear(in_features=embedding_dim, out_features=feedforward_dim, device=device, dtype=dtype),
-            fl.GeLU(),
-            fl.Linear(in_features=feedforward_dim, out_features=embedding_dim, device=device, dtype=dtype),
         )
 
 

--- a/tests/foundationals/clip/test_image_encoder.py
+++ b/tests/foundationals/clip/test_image_encoder.py
@@ -1,0 +1,53 @@
+import torch
+import pytest
+
+from warnings import warn
+from pathlib import Path
+
+from transformers import CLIPVisionModelWithProjection  # type: ignore
+
+from refiners.foundationals.clip.image_encoder import CLIPImageEncoderH
+from refiners.fluxion.utils import load_from_safetensors
+
+
+@pytest.fixture(scope="module")
+def our_encoder(test_weights_path: Path, test_device: torch.device) -> CLIPImageEncoderH:
+    weights = test_weights_path / "CLIPImageEncoderH.safetensors"
+    if not weights.is_file():
+        warn(f"could not find weights at {weights}, skipping")
+        pytest.skip(allow_module_level=True)
+    encoder = CLIPImageEncoderH(device=test_device)
+    tensors = load_from_safetensors(weights)
+    encoder.load_state_dict(tensors)
+    return encoder
+
+
+@pytest.fixture(scope="module")
+def stabilityai_unclip_weights_path(test_weights_path: Path):
+    r = test_weights_path / "stabilityai" / "stable-diffusion-2-1-unclip"
+    if not r.is_dir():
+        warn(f"could not find Stability AI weights at {r}, skipping")
+        pytest.skip(allow_module_level=True)
+    return r
+
+
+@pytest.fixture(scope="module")
+def ref_encoder(stabilityai_unclip_weights_path: Path, test_device: torch.device) -> CLIPVisionModelWithProjection:
+    return CLIPVisionModelWithProjection.from_pretrained(stabilityai_unclip_weights_path, subfolder="image_encoder").to(test_device)  # type: ignore
+
+
+def test_encoder(
+    ref_encoder: CLIPVisionModelWithProjection,
+    our_encoder: CLIPImageEncoderH,
+    test_device: torch.device,
+):
+    x = torch.randn(1, 3, 224, 224).to(test_device)
+
+    with torch.no_grad():
+        ref_embeddings = ref_encoder(x).image_embeds
+        our_embeddings = our_encoder(x)
+
+    assert ref_embeddings.shape == (1, 1024)
+    assert our_embeddings.shape == (1, 1024)
+
+    assert (our_embeddings - ref_embeddings).abs().max() < 0.01


### PR DESCRIPTION
Before this PR, Refiners only supported CLIP text encoders.