### PR TITLE
Make ModelConverter Class and Enable Use of Custom Layers

### DIFF
--- a/scripts/conversion/convert_diffusers_controlnet.py
+++ b/scripts/conversion/convert_diffusers_controlnet.py
@@ -50,7 +50,7 @@ def convert(args: Args) -> dict[str, torch.Tensor]:
     )
     target_order = converter._trace_module_execution_order(module=controlnet, args=(x,), keys_to_skip=[])
 
-    broken_k = (str(object=nn.Conv2d), (torch.Size([320, 320, 1, 1]), torch.Size([320])))
+    broken_k = (nn.Conv2d, (torch.Size([320, 320, 1, 1]), torch.Size([320])))
 
     expected_source_order = [
         "down_blocks.0.attentions.0.proj_in",
@@ -89,7 +89,7 @@ def convert(args: Args) -> dict[str, torch.Tensor]:
     assert target_order[broken_k] == expected_target_order
     source_order[broken_k] = fixed_source_order
 
-    broken_k = (str(object=nn.Conv2d), (torch.Size([640, 640, 1, 1]), torch.Size([640])))
+    broken_k = (nn.Conv2d, (torch.Size([640, 640, 1, 1]), torch.Size([640])))
 
     expected_source_order = [
         "down_blocks.1.attentions.0.proj_in",
@@ -125,7 +125,7 @@ def convert(args: Args) -> dict[str, torch.Tensor]:
     assert target_order[broken_k] == expected_target_order
     source_order[broken_k] = fixed_source_order
 
-    broken_k = (str(object=nn.Conv2d), (torch.Size([1280, 1280, 1, 1]), torch.Size([1280])))
+    broken_k = (nn.Conv2d, (torch.Size([1280, 1280, 1, 1]), torch.Size([1280])))
 
     expected_source_order = [
         "down_blocks.2.attentions.0.proj_in",

--- a/tests/fluxion/test_model_converter.py
+++ b/tests/fluxion/test_model_converter.py
@@ -1,0 +1,133 @@
+# pyright: reportPrivateUsage=false
+import pytest
+import torch
+from torch import nn, Tensor
+from refiners.fluxion.utils import manual_seed
+from refiners.fluxion.model_converter import ModelConverter, ConversionStage
+import refiners.fluxion.layers as fl
+
+
+class CustomBasicLayer1(fl.Module):
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(data=torch.randn(out_features, in_features))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x @ self.weight.t()
+
+
+class CustomBasicLayer2(fl.Module):
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(data=torch.randn(out_features, in_features))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x @ self.weight.t()
+
+
+# Source Model
+class SourceModel(fl.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear1 = fl.Linear(in_features=10, out_features=2)
+        self.activation = fl.ReLU()
+        self.custom_layers = nn.ModuleList(modules=[CustomBasicLayer1(in_features=2, out_features=2) for _ in range(3)])
+        self.flatten = fl.Flatten()
+        self.dropout = nn.Dropout(p=0.5)
+        self.conv = nn.Conv1d(in_channels=1, out_channels=10, kernel_size=3, stride=1, padding=1)
+        self.pool = nn.MaxPool1d(kernel_size=2, stride=2)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.linear1(x)
+        x = self.activation(x)
+        for layer in self.custom_layers:
+            x = layer(x)
+        x = self.flatten(x)
+        x = self.dropout(x)
+        x = x.view(1, 1, -1)
+        x = self.conv(x)
+        x = self.pool(x)
+        return x
+
+
+# Target Model (Purposely obfuscated but functionally equivalent)
+class TargetModel(fl.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.relu = fl.ReLU()
+        self.drop = nn.Dropout(0.5)
+        self.layers1 = nn.ModuleList(modules=[CustomBasicLayer2(in_features=2, out_features=2) for _ in range(3)])
+        self.flattenIt = fl.Flatten()
+        self.max_pool = nn.MaxPool1d(kernel_size=2, stride=2)
+        self.convolution = nn.Conv1d(in_channels=1, out_channels=10, kernel_size=3, stride=1, padding=1)
+        self.lin = fl.Linear(in_features=10, out_features=2)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.lin(x)
+        x = self.relu(x)
+        for layer in self.layers1:
+            x = layer(x)
+        x = self.flattenIt(x)
+        x = self.drop(x)
+        x = x.view(1, 1, -1)
+        x = self.convolution(x)
+        x = self.max_pool(x)
+        return x
+
+
+@pytest.fixture
+def source_model() -> SourceModel:
+    manual_seed(seed=2)
+    return SourceModel()
+
+
+@pytest.fixture
+def target_model() -> TargetModel:
+    manual_seed(seed=2)
+    return TargetModel()
+
+
+@pytest.fixture
+def model_converter(source_model: SourceModel, target_model: TargetModel) -> ModelConverter:
+    custom_layer_mapping: dict[type[nn.Module], type[nn.Module]] = {CustomBasicLayer1: CustomBasicLayer2}
+    return ModelConverter(
+        source_model=source_model, target_model=target_model, custom_layer_mapping=custom_layer_mapping, verbose=True
+    )
+
+
+@pytest.fixture
+def random_tensor() -> Tensor:
+    return torch.randn(1, 10)
+
+
+@pytest.fixture
+def source_args(random_tensor: Tensor) -> tuple[Tensor]:
+    return (random_tensor,)
+
+
+@pytest.fixture
+def target_args(random_tensor: Tensor) -> tuple[Tensor]:
+    return (random_tensor,)
+
+
+def test_converter_stages(
+    model_converter: ModelConverter, source_args: tuple[Tensor], target_args: tuple[Tensor]
+) -> None:
+    assert model_converter.stage == ConversionStage.INIT
+    assert model_converter._run_init_stage()
+    model_converter._increment_stage()
+
+    assert model_converter.stage == ConversionStage.BASIC_LAYERS_MATCH
+    assert model_converter._run_basic_layers_match_stage(source_args=source_args, target_args=target_args)
+    model_converter._increment_stage()
+
+    assert model_converter.stage == ConversionStage.SHAPE_AND_LAYERS_MATCH
+    assert model_converter._run_shape_and_layers_match_stage(source_args=source_args, target_args=target_args)
+    model_converter._increment_stage()
+
+    assert model_converter.stage == ConversionStage.MODELS_OUTPUT_AGREE
+
+
+def test_run(model_converter: ModelConverter, source_args: tuple[Tensor], target_args: tuple[Tensor]) -> None:
+    assert model_converter.run(source_args=source_args, target_args=target_args)
+    assert model_converter.stage == ConversionStage.MODELS_OUTPUT_AGREE

--- a/tests/foundationals/latent_diffusion/test_sdxl_unet.py
+++ b/tests/foundationals/latent_diffusion/test_sdxl_unet.py
@@ -6,7 +6,7 @@ import torch
 from refiners.fluxion.utils import manual_seed
 
 from refiners.foundationals.latent_diffusion.stable_diffusion_xl import SDXLUNet
-from refiners.fluxion.model_converter import ModelConverter
+from refiners.fluxion.model_converter import ConversionStage, ModelConverter
 
 
 @pytest.fixture(scope="module")
@@ -31,18 +31,8 @@ def diffusers_sdxl_unet(diffusers_sdxl: Any) -> Any:
 
 
 @pytest.fixture(scope="module")
-def sdxl_unet_weights_std(test_weights_path: Path) -> Path:
-    unet_weights_std = test_weights_path / "sdxl-unet.safetensors"
-    if not unet_weights_std.is_file():
-        warn(message=f"could not find weights at {unet_weights_std}, skipping")
-        pytest.skip(allow_module_level=True)
-    return unet_weights_std
-
-
-@pytest.fixture(scope="module")
-def refiners_sdxl_unet(sdxl_unet_weights_std: Path) -> SDXLUNet:
+def refiners_sdxl_unet() -> SDXLUNet:
     unet = SDXLUNet(in_channels=4)
-    unet.load_from_safetensors(tensors_path=sdxl_unet_weights_std)
     return unet
 
 
@@ -57,19 +47,27 @@ def test_sdxl_unet(diffusers_sdxl_unet: Any, refiners_sdxl_unet: SDXLUNet) -> No
     clip_text_embeddings = torch.randn(1, 77, 2048)
     added_cond_kwargs = {"text_embeds": torch.randn(1, 1280), "time_ids": torch.randn(1, 6)}
 
-    target.set_timestep(timestep=timestep)
-    target.set_clip_text_embedding(clip_text_embedding=clip_text_embeddings)
-    target.set_time_ids(time_ids=added_cond_kwargs["time_ids"])
-    target.set_pooled_text_embedding(pooled_text_embedding=added_cond_kwargs["text_embeds"])
     target_args = (x,)
     source_args = {
         "positional": (x, timestep, clip_text_embeddings),
         "keyword": {"added_cond_kwargs": added_cond_kwargs},
     }
 
-    converter = ModelConverter(source_model=source, target_model=target, verbose=False, threshold=1e-2)
+    old_forward = target.forward
+
+    def forward_with_context(self: Any, *args: Any, **kwargs: Any) -> Any:
+        target.set_timestep(timestep=timestep)
+        target.set_clip_text_embedding(clip_text_embedding=clip_text_embeddings)
+        target.set_time_ids(time_ids=added_cond_kwargs["time_ids"])
+        target.set_pooled_text_embedding(pooled_text_embedding=added_cond_kwargs["text_embeds"])
+        return old_forward(self, *args, **kwargs)
+
+    target.forward = forward_with_context
+
+    converter = ModelConverter(source_model=source, target_model=target, verbose=True, threshold=1e-2)
 
     assert converter.run(
         source_args=source_args,
         target_args=target_args,
     )
+    assert converter.stage == ConversionStage.MODELS_OUTPUT_AGREE


### PR DESCRIPTION
Currently the model conversion tools lacks configurability, this PR aims to remedy that by:

* Move into it's own module module_converter and own class ModuleConverter
* Add a state machine (ConversionStage enum) to do all operations at once
* Introduce custom mapping for basic layers that are not torch native

A following PR will add more clarity into the run logic, and more options to skip stage and provide custom key mapping.