### PR TITLE
Make breakpoint a ContextModule

### DIFF
--- a/src/refiners/fluxion/layers/chain.py
+++ b/src/refiners/fluxion/layers/chain.py
@@ -452,7 +452,7 @@ class Residual(Sum):
         super().__init__(Identity(), Chain(*modules))
 
 
-class Breakpoint(Module):
+class Breakpoint(ContextModule):
     def __init__(self, vscode: bool = True):
         super().__init__()
         self.vscode = vscode


### PR DESCRIPTION
This is convenient when debugging because this allows you to access context but also parents