### PR TITLE
support ViT-G/14 in CLIP image encoder

### DIFF
--- a/scripts/conversion/convert_transformers_clip_image_model.py
+++ b/scripts/conversion/convert_transformers_clip_image_model.py
@@ -15,6 +15,7 @@ class Args(argparse.Namespace):
     output_path: str | None
     half: bool
     verbose: bool
+    threshold: float
 
 
 def setup_converter(args: Args) -> ModelConverter:
@@ -79,7 +80,7 @@ def setup_converter(args: Args) -> ModelConverter:
     # Ad hoc post-conversion steps
     class_embedding.parameter = torch.nn.Parameter(source.vision_model.embeddings.class_embedding.clone())  # type: ignore
 
-    assert converter.compare_models((x,), threshold=1e-2)
+    assert converter.compare_models((x,), threshold=args.threshold)
 
     return converter
 
@@ -122,6 +123,7 @@ def main() -> None:
         default=False,
         help="Prints additional information during conversion. Default: False",
     )
+    parser.add_argument("--threshold", type=float, default=1e-2, help="Threshold for model comparison. Default: 1e-2")
     args = parser.parse_args(namespace=Args())
     if args.output_path is None:
         args.output_path = f"{Path(args.source_path).stem}-{args.subfolder}.safetensors"

--- a/src/refiners/foundationals/clip/image_encoder.py
+++ b/src/refiners/foundationals/clip/image_encoder.py
@@ -180,3 +180,17 @@ class CLIPImageEncoderH(CLIPImageEncoder):
             device=device,
             dtype=dtype,
         )
+
+
+class CLIPImageEncoderG(CLIPImageEncoder):
+    def __init__(self, device: Device | str | None = None, dtype: DType | None = None) -> None:
+        super().__init__(
+            embedding_dim=1664,
+            output_dim=1280,
+            patch_size=14,
+            num_layers=48,
+            num_attention_heads=16,
+            feedforward_dim=8192,
+            device=device,
+            dtype=dtype,
+        )


### PR DESCRIPTION
aka ViT-bigG/14 in [OpenCLIP](https://github.com/mlfoundations/open_clip)

Tested via model conversion (which includes models' outputs comparison):

```bash
sed --in-place='.bkp' \
  's/"architectures": null,//' \
  /path/to/h94/IP-Adapter/sdxl_models/image_encoder/config.json
python scripts/conversion/convert_transformers_clip_image_model.py \
    --from /path/to/h94/IP-Adapter/sdxl_models \
    --half \
    --threshold 2e-2
```

> Note: https://huggingface.co/h94/IP-Adapter/blob/main/sdxl_models/image_encoder/config.json is erroneous, i.e. there is an extra `"architectures": null` in addition to `"architectures": ["CLIPVisionModelWithProjection"]`. Hence the preliminary `sed` command.
