### PR TITLE
make text encoder converter support SDXL

### DIFF
--- a/scripts/conversion/convert_diffusers_unet.py
+++ b/scripts/conversion/convert_diffusers_unet.py
@@ -76,7 +76,7 @@ def main() -> None:
             " source path."
         ),
     )
-    parser.add_argument("--half", action="store_true", default=True, help="Convert to half precision. Default: True")
+    parser.add_argument("--half", action="store_true", help="Convert to half precision. Default: True")
     parser.add_argument(
         "--verbose",
         action="store_true",

--- a/scripts/conversion/convert_transformers_clip_image_model.py
+++ b/scripts/conversion/convert_transformers_clip_image_model.py
@@ -116,7 +116,7 @@ def main() -> None:
             " source path."
         ),
     )
-    parser.add_argument("--half", action="store_true", default=True, help="Convert to half precision. Default: True")
+    parser.add_argument("--half", action="store_true", help="Convert to half precision. Default: True")
     parser.add_argument(
         "--verbose",
         action="store_true",


### PR DESCRIPTION
i.e. directly serialize the `DoubleTextEncoder` weights.

E.g.:

```bash
python scripts/conversion/convert_transformers_clip_text_model.py \
  --from /path/to/stabilityai/stable-diffusion-xl-base-1.0 \
  --subfolder2 text_encoder_2 \
  --to DoubleCLIPTextEncoder.safetensors
```