### PR TITLE
Use bias correction on Prodigy

### DIFF
--- a/src/refiners/training_utils/config.py
+++ b/src/refiners/training_utils/config.py
@@ -165,6 +165,7 @@ class OptimizerConfig(BaseModel):
                     betas=self.betas,
                     weight_decay=self.weight_decay,  # type: ignore
                     safeguard_warmup=True,
+                    use_bias_correction=True,  # recommended for diffusion models
                 )
 
 


### PR DESCRIPTION
As advised on [Prodigy](https://github.com/konstmish/prodigy)'s official repository, the fine-tuning of diffusion models now uses bias correction.