### PR TITLE
IP adapter rework

### DIFF
--- a/scripts/conversion/convert_diffusers_ip_adapter.py
+++ b/scripts/conversion/convert_diffusers_ip_adapter.py
@@ -92,9 +92,13 @@ def main() -> None:
         v_ip = f"{cross_attn_index}.to_v_ip.weight"
 
         # Ignore Wq, Wk, Wv and Proj (hence strict=False): at runtime, they will be part of the UNet original weights
+
+        names = [k for k, _ in cross_attn.named_parameters()]
+        assert len(names) == 2
+
         cross_attn_state_dict: dict[str, Any] = {
-            cross_attn.get_parameter_name("wk_prime"): ip_adapter_weights[k_ip],
-            cross_attn.get_parameter_name("wv_prime"): ip_adapter_weights[v_ip],
+            names[0]: ip_adapter_weights[k_ip],
+            names[1]: ip_adapter_weights[v_ip],
         }
         cross_attn.load_state_dict(state_dict=cross_attn_state_dict, strict=False)
 

--- a/tests/foundationals/latent_diffusion/test_controlnet.py
+++ b/tests/foundationals/latent_diffusion/test_controlnet.py
@@ -4,6 +4,7 @@ import torch
 import pytest
 
 import refiners.fluxion.layers as fl
+from refiners.fluxion.adapters.adapter import lookup_top_adapter
 from refiners.foundationals.latent_diffusion import SD1UNet, SD1ControlnetAdapter
 from refiners.foundationals.latent_diffusion.stable_diffusion_1.controlnet import Controlnet
 
@@ -56,7 +57,7 @@ def test_two_controlnets_eject_bottom_up(unet: SD1UNet) -> None:
     assert cn1.parent == original_parent
     assert len(list(unet.walk(Controlnet))) == 2
     assert cn1.target == unet
-    assert cn1.lookup_actual_target() == cn2
+    assert lookup_top_adapter(cn1, cn1.target) == cn2
 
     cn2.eject()
     assert unet.parent == cn1

--- a/tests/foundationals/latent_diffusion/test_image_prompt.py
+++ b/tests/foundationals/latent_diffusion/test_image_prompt.py
@@ -1,0 +1,14 @@
+import refiners.fluxion.layers as fl
+from refiners.foundationals.latent_diffusion.image_prompt import CrossAttentionAdapter
+
+
+def test_cross_attention_adapter() -> None:
+    base = fl.Chain(fl.Attention(embedding_dim=4))
+    adapter = CrossAttentionAdapter(base.Attention).inject()
+
+    assert list(base) == [adapter]
+
+    adapter.eject()
+
+    assert len(base) == 1
+    assert isinstance(base[0], fl.Attention)

--- a/tests/foundationals/latent_diffusion/test_image_prompt.py
+++ b/tests/foundationals/latent_diffusion/test_image_prompt.py
@@ -1,5 +1,5 @@
 import refiners.fluxion.layers as fl
-from refiners.foundationals.latent_diffusion.image_prompt import CrossAttentionAdapter
+from refiners.foundationals.latent_diffusion.image_prompt import CrossAttentionAdapter, InjectionPoint
 
 
 def test_cross_attention_adapter() -> None:
@@ -7,8 +7,23 @@ def test_cross_attention_adapter() -> None:
     adapter = CrossAttentionAdapter(base.Attention).inject()
 
     assert list(base) == [adapter]
+    assert len(list(adapter.layers(fl.Linear))) == 6
+    assert len(list(base.layers(fl.Linear))) == 6
+
+    injection_points = list(adapter.layers(InjectionPoint))
+    assert len(injection_points) == 4
+    for ip in injection_points:
+        assert len(ip) == 1
+        assert isinstance(ip[0], fl.Linear)
 
     adapter.eject()
 
     assert len(base) == 1
     assert isinstance(base[0], fl.Attention)
+    assert len(list(adapter.layers(fl.Linear))) == 2
+    assert len(list(base.layers(fl.Linear))) == 4
+
+    injection_points = list(adapter.layers(InjectionPoint))
+    assert len(injection_points) == 4
+    for ip in injection_points:
+        assert len(ip) == 0


### PR DESCRIPTION
This PR changes the IP Adapter implementation style to be more "Refiners-ish" (relying on tree manipulation using Chain methods).

It results in less code, removes the need for `get_parameter_name` and avoids requiring weights being loaded during adapter init.