### PR TITLE
correctly initialize context in structural_copy

### DIFF
--- a/src/refiners/fluxion/layers/chain.py
+++ b/src/refiners/fluxion/layers/chain.py
@@ -376,7 +376,7 @@ class Chain(ContextModule):
 
         modules = [structural_copy(m) for m in self]
         clone = super().structural_copy()
-        clone._provider = ContextProvider()
+        clone._provider = ContextProvider.create(clone.init_context())
 
         for module in modules:
             clone.append(module=module)


### PR DESCRIPTION
fixes a regression introduced in 1cb798e8ae9be88c9b4ee27d73ae6c1c501c91ea