### PR TITLE
Prevent setattr Module Registration for Chains

### DIFF
--- a/src/refiners/fluxion/layers/chain.py
+++ b/src/refiners/fluxion/layers/chain.py
@@ -143,6 +143,14 @@ class Chain(ContextModule):
             if isinstance(module, ContextModule) and module.parent != self:
                 module._set_parent(self)
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        if isinstance(value, torch.nn.Module):
+            raise ValueError(
+                "Chain does not support setting modules by attribute. Instead, use a mutation method like `append` or"
+                " wrap it within a single element list to prevent pytorch from registering it as a submodule."
+            )
+        super().__setattr__(name, value)
+
     @property
     def provider(self) -> ContextProvider:
         return self._provider

--- a/src/refiners/fluxion/layers/module.py
+++ b/src/refiners/fluxion/layers/module.py
@@ -11,7 +11,7 @@ from torch.nn.modules.module import Module as TorchModule
 from refiners.fluxion.utils import load_from_safetensors
 from refiners.fluxion.context import Context, ContextProvider
 
-from typing import Callable, TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from refiners.fluxion.layers.chain import Chain
@@ -26,11 +26,14 @@ class Module(TorchModule):
     _buffers: dict[str, Any]
     _tag: str = ""
 
-    __getattr__: Callable[["Module", str], Any]  # type: ignore
-    __setattr__: Callable[["Module", str, Any], None]  # type: ignore
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, *kwargs)  # type: ignore
+        super().__init__(*args, *kwargs)  # type: ignore[reportUnknownMemberType]
+
+    def __getattr__(self, name: str) -> Any:
+        return super().__getattr__(name=name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        return super().__setattr__(name=name, value=value)
 
     def load_from_safetensors(self, tensors_path: str | Path, strict: bool = True) -> "Module":
         state_dict = load_from_safetensors(tensors_path)

--- a/tests/fluxion/layers/test_chain.py
+++ b/tests/fluxion/layers/test_chain.py
@@ -217,3 +217,12 @@ def test_chain_structural_copy() -> None:
     y2 = m2(x)
     assert y2.shape == (7, 12)
     torch.equal(y2, y)
+
+
+def test_setattr_dont_register() -> None:
+    chain = fl.Chain(fl.Linear(in_features=1, out_features=1), fl.Linear(in_features=1, out_features=1))
+
+    with pytest.raises(expected_exception=ValueError):
+        chain.foo = fl.Linear(in_features=1, out_features=1)
+
+    assert module_keys(chain=chain) == ["Linear_1", "Linear_2"]


### PR DESCRIPTION
Currently when setting a Pytorch module as attribute in a Chain, it gets registered as a submodule and appended to the Chain (and attributed a different key). This can lead to very confusing bugs since this affects the forward of the Chain. A solution to prevent this is to wrap the submodule in a list or tuple to prevent this from happening.
