### PR TITLE
Improve Debug Print for Chain _call_layer Method

### DIFF
--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -137,3 +137,23 @@ def load_metadata_from_safetensors(path: Path | str) -> dict[str, str] | None:
 
 def save_to_safetensors(path: Path | str, tensors: dict[str, Tensor], metadata: dict[str, str] | None = None) -> None:
     _save_file(tensors, path, metadata)  # type: ignore
+
+
+def summarize_tensor(tensor: torch.Tensor, /) -> str:
+    return (
+        "Tensor("
+        + ", ".join(
+            [
+                f"shape=({', '.join(map(str, tensor.shape))})",
+                f"dtype={str(object=tensor.dtype).removeprefix('torch.')}",
+                f"device={tensor.device}",
+                f"min={tensor.min():.2f}",  # type: ignore
+                f"max={tensor.max():.2f}",  # type: ignore
+                f"mean={tensor.mean():.2f}",
+                f"std={tensor.std():.2f}",
+                f"norm={norm(x=tensor):.2f}",
+                f"grad={tensor.requires_grad}",
+            ]
+        )
+        + ")"
+    )

--- a/tests/fluxion/layers/test_chain.py
+++ b/tests/fluxion/layers/test_chain.py
@@ -226,3 +226,19 @@ def test_setattr_dont_register() -> None:
         chain.foo = fl.Linear(in_features=1, out_features=1)
 
     assert module_keys(chain=chain) == ["Linear_1", "Linear_2"]
+
+
+EXPECTED_TREE = (
+    "(CHAIN)\n    ├── Linear(in_features=1, out_features=1) (x2)\n    └── (CHAIN)\n        ├── Linear(in_features=1,"
+    " out_features=1) #1\n        └── Linear(in_features=2, out_features=1) #2"
+)
+
+
+def test_debug_print() -> None:
+    chain = fl.Chain(
+        fl.Linear(1, 1),
+        fl.Linear(1, 1),
+        fl.Chain(fl.Linear(1, 1), fl.Linear(2, 1)),
+    )
+
+    assert chain._show_error_in_tree("Chain.Linear_2") == EXPECTED_TREE  # type: ignore[reportPrivateUsage]


### PR DESCRIPTION
When an error arises in a Chain, it is difficult to parse since it the original error can obfuscated because of very deep nesting. Also the native repr of Pytorch Tensor is not really useful for debugging purposes.

We improve that by:
 -> Cleaning the traceback stack and keeping only relevant information
 -> Showing a summerize_tensor print for the args
 -> Printing trees to show where the error occurs through nesting