### PR TITLE
feature: support self-attention guidance with SD1 inpainting model

### DIFF
--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
@@ -143,3 +143,30 @@ class StableDiffusion_1_Inpainting(StableDiffusion_1):
         self.target_image_latents = self.lda.encode(x=masked_init_image)
 
         return self.mask_latents, self.target_image_latents
+
+    def compute_self_attention_guidance(
+        self, x: Tensor, noise: Tensor, step: int, *, clip_text_embedding: Tensor, **kwargs: Tensor
+    ) -> Tensor:
+        sag = self._find_sag_adapter()
+        assert sag is not None
+        assert self.mask_latents is not None
+        assert self.target_image_latents is not None
+
+        degraded_latents = sag.compute_degraded_latents(
+            scheduler=self.scheduler,
+            latents=x,
+            noise=noise,
+            step=step,
+            classifier_free_guidance=True,
+        )
+
+        negative_embedding, _ = clip_text_embedding.chunk(2)
+        timestep = self.scheduler.timesteps[step].unsqueeze(dim=0)
+        self.set_unet_context(timestep=timestep, clip_text_embedding=negative_embedding, **kwargs)
+        x = torch.cat(
+            tensors=(degraded_latents, self.mask_latents, self.target_image_latents),
+            dim=1,
+        )
+        degraded_noise = self.unet(x)
+
+        return sag.scale * (noise - degraded_noise)


### PR DESCRIPTION
This is basically the change, which adds the mask and target image latents when inputing to the unet and then discards them.  I have not done extensive comparisons to validate the efficacy of this but it appears to work.

I also wonder if the effect would be improved if the self-attention was focused on just the area being inpainted. 

```python
        x = torch.cat(
            tensors=(degraded_latents, self.mask_latents, self.target_image_latents),
            dim=1,
        )
        result = self.unet(x)
        degraded_noise = result[:, :4, :, :]
```
Comparison
![animated_with_text](https://github.com/finegrain-ai/refiners/assets/1217531/c42d082b-0274-4303-aa99-d6646ce2f7ec)
![animated_with_text_new](https://github.com/finegrain-ai/refiners/assets/1217531/cf379933-6b31-407d-ac30-d80c0f0210c0)


Inpainting without Self-Attention Guidance
![test_inpainting_bench_](https://github.com/finegrain-ai/refiners/assets/1217531/9ba17d6a-6b37-4a0c-aaa4-ad15566824c4)

Inpainting with Self-Attention Guidance
![test_inpainting_bench_with_sag](https://github.com/finegrain-ai/refiners/assets/1217531/45f9ed73-4f5a-4b4f-b8b7-8caa750ae5b7)

Original:
![test_inpainting_bench__orig](https://github.com/finegrain-ai/refiners/assets/1217531/c1458129-d858-47bc-a99f-7e4eaa92d2a1)

