### PR TITLE
feature: create seamless tileable images in x or y dimension

### DIFF
--- a/src/refiners/fluxion/layers/chain.py
+++ b/src/refiners/fluxion/layers/chain.py
@@ -257,6 +257,7 @@ class Chain(ContextModule):
         try:
             return layer(*args)
         except Exception as e:
+            raise e
             exc_type, _, exc_traceback = sys.exc_info()
             assert exc_type
             tb_list = traceback.extract_tb(tb=exc_traceback)

--- a/src/refiners/foundationals/latent_diffusion/seamless_tiles.py
+++ b/src/refiners/foundationals/latent_diffusion/seamless_tiles.py
@@ -1,0 +1,88 @@
+"""Code for enabling single direction circular padding on Conv2d layers."""
+
+from typing import Literal
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+import refiners.fluxion.layers as fl
+from refiners.fluxion.adapters import Adapter
+from refiners.foundationals.latent_diffusion.stable_diffusion_1.unet import SD1UNet
+
+TileModeType = Literal["", "x", "y", "xy"]
+PaddingModeType = Literal["circular", "constant"]
+
+
+class SeamlessConv2dWrapper(fl.Module):
+    def __init__(self, target: fl.Conv2d, tile_adapter: "TilingAdapter") -> None:
+        super().__init__()
+        self.target = target
+        self.tile_adapter = tile_adapter
+
+    def _conv_forward(self, input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+        tile_mode = self.tile_adapter.tile_mode
+        padding_mode_x = "circular" if "x" in tile_mode else "constant"
+        padding_mode_y = "circular" if "y" in tile_mode else "constant"
+
+        if padding_mode_y == padding_mode_x:
+            original_padding_mode = self.target.padding_mode
+            try:
+                self.target.padding_mode = padding_mode_x
+                return self.target._conv_forward(input, weight, bias)  # type: ignore[protected-access]
+            finally:
+                self.target.padding_mode = original_padding_mode
+
+        rprt = self.target._reversed_padding_repeated_twice  # type: ignore[protected-access]
+        padding_x = (rprt[0], rprt[1], 0, 0)
+        padding_y = (0, 0, rprt[2], rprt[3])
+
+        w1 = F.pad(input, padding_x, mode=padding_mode_x)
+        del input
+
+        w2 = F.pad(w1, padding_y, mode=padding_mode_y)
+        del w1
+
+        return F.conv2d(w2, weight, bias, self.target.stride, (0, 0), self.target.dilation, self.target.groups)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return self._conv_forward(input, self.target.weight, self.target.bias)
+
+
+class TilingConv2dAdapter(fl.Chain, Adapter[fl.Conv2d]):
+    def __init__(self, target: fl.Conv2d, tile_adapter: "TilingAdapter") -> None:
+        with self.setup_adapter(target):
+            super().__init__(
+                SeamlessConv2dWrapper(target, tile_adapter=tile_adapter),
+            )
+
+
+def find_parent(model, child: nn.Module) -> fl.Chain | None:
+    for module in model.modules():
+        if child in module.children():
+            return module  # type: ignore[no-any-return]
+    return None
+
+
+class TilingAdapter(fl.Passthrough, Adapter[SD1UNet]):
+    def __init__(self, target: SD1UNet, tile_mode: TileModeType = "") -> None:
+        self.tile_mode = tile_mode
+        with self.setup_adapter(target):
+            super().__init__(target)
+
+    def inject(self, parent: fl.Chain | None = None) -> "TilingAdapter":
+        super().inject(parent)
+        for module in self.target.modules():
+            if isinstance(module, fl.Conv2d):
+                cparent = find_parent(self.target, module)
+                TilingConv2dAdapter(module, tile_adapter=self).inject(cparent)
+        return self
+
+    def eject(self):
+        for module in self.target.modules():
+            if isinstance(module, TilingConv2dAdapter):
+                module.eject()
+        super().eject()
+
+    def set_tile_mode(self, tile_mode: TileModeType) -> None:
+        self.tile_mode = tile_mode

--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
@@ -1,5 +1,9 @@
+from typing import Literal
+
 import numpy as np
 import torch
+from torch import nn
+from torch.nn import functional as F
 from PIL import Image
 from torch import Tensor, device as Device, dtype as DType
 
@@ -11,6 +15,9 @@ from refiners.foundationals.latent_diffusion.schedulers.dpm_solver import DPMSol
 from refiners.foundationals.latent_diffusion.schedulers.scheduler import Scheduler
 from refiners.foundationals.latent_diffusion.stable_diffusion_1.self_attention_guidance import SD1SAGAdapter
 from refiners.foundationals.latent_diffusion.stable_diffusion_1.unet import SD1UNet
+
+
+TileModeType = Literal["", "x", "y", "xy"]
 
 
 class SD1Autoencoder(LatentDiffusionAutoencoder):
@@ -95,6 +102,55 @@ class StableDiffusion_1(LatentDiffusionModel):
         degraded_noise = self.unet(degraded_latents)
 
         return sag.scale * (noise - degraded_noise)
+
+    def set_tile_mode(self, tile_mode: TileModeType = ""):
+        """
+        For creating seamless tile images.
+
+        Args:
+            tile_mode: One of "", "x", "y", "xy". If "x", the image will be tiled horizontally. If "y", the image will be
+                tiled vertically. If "xy", the image will be tiled both horizontally and vertically.
+        """
+
+        tile_x = "x" in tile_mode
+        tile_y = "y" in tile_mode
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                if not hasattr(m, "_orig_conv_forward"):
+                    # patch with a function that can handle tiling in a single direction
+                    m._initial_padding_mode = m.padding_mode
+                    m._orig_conv_forward = m._conv_forward
+                    m._conv_forward = _TileModeConv2DConvForward.__get__(m, nn.Conv2d)
+                m.padding_modeX = "circular" if tile_x else "constant"
+                m.padding_modeY = "circular" if tile_y else "constant"
+                if m.padding_modeY == m.padding_modeX:
+                    m.padding_mode = m.padding_modeX
+                m.paddingX = (
+                    m._reversed_padding_repeated_twice[0],
+                    m._reversed_padding_repeated_twice[1],
+                    0,
+                    0,
+                )
+                m.paddingY = (
+                    0,
+                    0,
+                    m._reversed_padding_repeated_twice[2],
+                    m._reversed_padding_repeated_twice[3],
+                )
+
+
+def _TileModeConv2DConvForward(self, input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):  # noqa
+    if self.padding_modeX == self.padding_modeY:
+        self.padding_mode = self.padding_modeX
+        return self._orig_conv_forward(input, weight, bias)
+
+    w1 = F.pad(input, self.paddingX, mode=self.padding_modeX)
+    del input
+
+    w2 = F.pad(w1, self.paddingY, mode=self.padding_modeY)
+    del w1
+
+    return F.conv2d(w2, weight, bias, self.stride, _pair(0), self.dilation, self.groups)
 
 
 class StableDiffusion_1_Inpainting(StableDiffusion_1):


### PR DESCRIPTION
Adds a seamless tile mode but does so in a way you guys probably won't like :-)  Opening the pull request to have the discussion.

Tile mode can be set to tile in both directions or only "x" or "y".  Set an image as desktop background in tile mode to really get the full effect.

I suspect this will work with SDXL as well but haven't tried it yet.

Examples:
![022785_781162360_kdpmpp2m15_PS7 5_white_marble_quartz_with_gold_veins_ generated](https://github.com/finegrain-ai/refiners/assets/1217531/fefd356d-3050-4dfc-89a6-3f30ae8e91ab)
![284143311-fefd356d-3050-4dfc-89a6-3f30ae8e91ab_reduced_perfect_loop](https://github.com/finegrain-ai/refiners/assets/1217531/7e309b3d-2ab2-45e3-8250-3f39d0759034)

![tiled_image_1_2x3](https://github.com/finegrain-ai/refiners/assets/1217531/2c921da8-f096-41f3-93cd-1c0352b718a1)


![022755_297564700_kdpmpp2m35_PS7 5_blueberries_ generated](https://github.com/finegrain-ai/refiners/assets/1217531/06c64067-aa5d-4f9f-8b50-d691200c4f75)
![284144042-06c64067-aa5d-4f9f-8b50-d691200c4f75_reduced_perfect_loop](https://github.com/finegrain-ai/refiners/assets/1217531/05debf87-8c22-49f5-8f7d-990996bb8a02)
![tiled_image_2_2x3](https://github.com/finegrain-ai/refiners/assets/1217531/55206ba1-cdd9-4a32-bad3-1311d95197d3)

![022559_809130920_kdpmpp2m35_PS7 5_an_oil_drop_ generated](https://github.com/finegrain-ai/refiners/assets/1217531/8bb35e8c-ecf2-49fb-8aed-b3e9add46293)
![022559_809130920_kdpmpp2m35_PS7 5_an_oil_drop_ generated _reduced_perfect_loop](https://github.com/finegrain-ai/refiners/assets/1217531/bca9ce72-668d-4c95-822f-dc2b14e56d0f)
![tiled_image_2x3](https://github.com/finegrain-ai/refiners/assets/1217531/d6ebad4a-9dcf-47f1-b478-90756450ef1a)
