### PR TITLE
fix typo in finetune-ldm config

### DIFF
--- a/configs/finetune-ldm.toml
+++ b/configs/finetune-ldm.toml
@@ -1,7 +1,7 @@
 script = "finetune-ldm.py" # not used for now
 
 [wandb]
-offline = "offline"
+mode = "offline"
 entity = "acme"
 project = "test-ldm-training"
 


### PR DESCRIPTION
Before this fix, it was always using "online" (W&B default).