### PR TITLE
pyproject.toml: add example for combine-as-imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,10 @@ ignore = [
 line-length = 120
 
 [tool.ruff.lint.isort]
+# Allow this kind of import on a single line:
+#
+#     from torch import device as Device, dtype as DType
+#
 combine-as-imports = true
 
 [tool.docformatter]


### PR DESCRIPTION
b44d612 was misleading (s/avoid/allow/)