### PR TITLE
Add tomli to Training Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ training = [
     # https://github.com/TimDettmers/bitsandbytes/pull/525
     "scipy>=1.11.4",
     "datasets>=2.15.0",
+    "tomli>=2.0.1",
 ]
 test = [
     "diffusers>=0.24.0",


### PR DESCRIPTION
With python 3.10 you still need `tomli` to read TOML files.