### PR TITLE
Make summarize_tensor robust to non-float dtypes 

### DIFF
--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -195,10 +195,9 @@ def summarize_tensor(tensor: torch.Tensor, /) -> str:
         f"max={tensor.max():.2f}",  # type: ignore
     ]
 
-    # Only add mean, std, and norm for float and complex tensors
-    if tensor.dtype == torch.float or tensor.dtype == torch.double:
-        info_list.extend([f"mean={tensor.mean():.2f}", f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}"])
+    if tensor.dtype == torch.float or tensor.dtype == torch.complex:
+        info_list.append(f"mean={tensor.mean():.2f}")
 
-    info_list.append(f"grad={tensor.requires_grad}")
+    info_list.extend([f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}", f"grad={tensor.requires_grad}"])
 
     return "Tensor(" + ", ".join(info_list) + ")"

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -187,20 +187,18 @@ def save_to_safetensors(path: Path | str, tensors: dict[str, Tensor], metadata: 
 
 
 def summarize_tensor(tensor: torch.Tensor, /) -> str:
-    return (
-        "Tensor("
-        + ", ".join(
-            [
-                f"shape=({', '.join(map(str, tensor.shape))})",
-                f"dtype={str(object=tensor.dtype).removeprefix('torch.')}",
-                f"device={tensor.device}",
-                f"min={tensor.min():.2f}",  # type: ignore
-                f"max={tensor.max():.2f}",  # type: ignore
-                f"mean={tensor.mean():.2f}",
-                f"std={tensor.std():.2f}",
-                f"norm={norm(x=tensor):.2f}",
-                f"grad={tensor.requires_grad}",
-            ]
-        )
-        + ")"
-    )
+    info_list = [
+        f"shape=({', '.join(map(str, tensor.shape))})",
+        f"dtype={str(object=tensor.dtype).removeprefix('torch.')}",
+        f"device={tensor.device}",
+        f"min={tensor.min():.2f}",  # type: ignore
+        f"max={tensor.max():.2f}",  # type: ignore
+    ]
+
+    # Only add mean, std, and norm for float and complex tensors
+    if tensor.dtype == torch.float or tensor.dtype == torch.double:
+        info_list.extend([f"mean={tensor.mean():.2f}", f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}"])
+
+    info_list.append(f"grad={tensor.requires_grad}")
+
+    return "Tensor(" + ", ".join(info_list) + ")"

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -191,13 +191,18 @@ def summarize_tensor(tensor: torch.Tensor, /) -> str:
         f"shape=({', '.join(map(str, tensor.shape))})",
         f"dtype={str(object=tensor.dtype).removeprefix('torch.')}",
         f"device={tensor.device}",
-        f"min={tensor.min():.2f}",  # type: ignore
-        f"max={tensor.max():.2f}",  # type: ignore
     ]
+    if not tensor.is_complex():
+        info_list.extend(
+            [
+                f"min={tensor.min():.2f}",  # type: ignore
+                f"max={tensor.max():.2f}",  # type: ignore
+            ]
+        )
 
-    if tensor.dtype == torch.float or tensor.dtype == torch.complex:
-        info_list.append(f"mean={tensor.mean():.2f}")
+    if tensor.dtype == torch.float or tensor.is_complex():
+        info_list.extend([f"mean={tensor.mean():.2f}", f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}"])
 
-    info_list.extend([f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}", f"grad={tensor.requires_grad}"])
+    info_list.extend([f"grad={tensor.requires_grad}"])
 
     return "Tensor(" + ", ".join(info_list) + ")"

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -200,9 +200,13 @@ def summarize_tensor(tensor: torch.Tensor, /) -> str:
             ]
         )
 
-    if tensor.dtype == torch.float or tensor.is_complex():
-        info_list.extend([f"mean={tensor.mean():.2f}", f"std={tensor.std():.2f}", f"norm={norm(x=tensor):.2f}"])
-
-    info_list.extend([f"grad={tensor.requires_grad}"])
+    info_list.extend(
+        [
+            f"mean={tensor.float().mean():.2f}",
+            f"std={tensor.float().std():.2f}",
+            f"norm={norm(x=tensor.float()):.2f}",
+            f"grad={tensor.requires_grad}",
+        ]
+    )
 
     return "Tensor(" + ", ".join(info_list) + ")"

--- a/tests/fluxion/test_utils.py
+++ b/tests/fluxion/test_utils.py
@@ -7,7 +7,14 @@ from PIL import Image
 from torch import device as Device, dtype as DType
 from torchvision.transforms.functional import gaussian_blur as torch_gaussian_blur  # type: ignore
 
-from refiners.fluxion.utils import gaussian_blur, image_to_tensor, manual_seed, no_grad, tensor_to_image
+from refiners.fluxion.utils import (
+    gaussian_blur,
+    image_to_tensor,
+    manual_seed,
+    no_grad,
+    summarize_tensor,
+    tensor_to_image,
+)
 
 
 @dataclass
@@ -62,6 +69,13 @@ def test_tensor_to_image() -> None:
     assert tensor_to_image(torch.zeros(1, 3, 512, 512)).mode == "RGB"
     assert tensor_to_image(torch.zeros(1, 1, 512, 512)).mode == "L"
     assert tensor_to_image(torch.zeros(1, 4, 512, 512)).mode == "RGBA"
+
+
+def test_summarize_tensor() -> None:
+    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).int())) == str
+    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).float())) == str
+    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).double())) == str
+    assert type(summarize_tensor(torch.complex(torch.zeros(1, 3, 512, 512), torch.zeros(1, 3, 512, 512)))) == str
 
 
 def test_no_grad() -> None:

--- a/tests/fluxion/test_utils.py
+++ b/tests/fluxion/test_utils.py
@@ -72,10 +72,12 @@ def test_tensor_to_image() -> None:
 
 
 def test_summarize_tensor() -> None:
-    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).int())) == str
-    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).float())) == str
-    assert type(summarize_tensor(torch.zeros(1, 3, 512, 512).double())) == str
-    assert type(summarize_tensor(torch.complex(torch.zeros(1, 3, 512, 512), torch.zeros(1, 3, 512, 512)))) == str
+    assert summarize_tensor(torch.zeros(1, 3, 512, 512).int())
+    assert summarize_tensor(torch.zeros(1, 3, 512, 512).float())
+    assert summarize_tensor(torch.zeros(1, 3, 512, 512).double())
+    assert summarize_tensor(torch.complex(torch.zeros(1, 3, 512, 512), torch.zeros(1, 3, 512, 512)))
+    assert summarize_tensor(torch.zeros(1, 3, 512, 512).bfloat16())
+    assert summarize_tensor(torch.zeros(1, 3, 512, 512).bool())
 
 
 def test_no_grad() -> None:


### PR DESCRIPTION
Current implementation of summarize_tensor can raise secondary error while obfuscating the original error.

## Actual

When doing some experiments, the stack was displaying a secondary error

```
Traceback (most recent call last):
  File "/home/pierre/dev/refiners/scripts/training/finetune-ldm-color-palette.py", line 15, in <module>
    trainer.train()
  File "/home/pierre/dev/refiners/src/refiners/training_utils/trainer.py", line 89, in inner_wrapper
    result = func(*args, **kwargs)
  File "/home/pierre/dev/refiners/src/refiners/training_utils/trainer.py", line 528, in train
    self.epoch()
  File "/home/pierre/dev/refiners/src/refiners/training_utils/trainer.py", line 512, in epoch
    self.step(batch=batch)
  File "/home/pierre/dev/refiners/src/refiners/training_utils/trainer.py", line 503, in step
    loss = self.compute_loss(batch=batch)
  File "/home/pierre/dev/refiners/src/refiners/training_utils/color_palette.py", line 234, in compute_loss
    prediction = self.unet(noisy_latents)
  File "/home/pierre/anaconda3/envs/refiners/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/pierre/anaconda3/envs/refiners/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/pierre/dev/refiners/src/refiners/fluxion/layers/chain.py", line 279, in forward
    result = self._call_layer(layer, name, *intermediate_args)
  File "/home/pierre/dev/refiners/src/refiners/fluxion/layers/chain.py", line 273, in _call_layer
    raise ChainError(message) from None
refiners.fluxion.layers.chain.ChainError: RuntimeError:
   File "/home/pierre/dev/refiners/src/refiners/fluxion/utils.py", line 199, in summarize_tensor
    f"mean={tensor.mean():.2f}",

mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype. Got: Long
```

## Expected

I'm expecting to get to orignal error in the stack

Which in my case was 

`Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0! (when checking argument for argument mat1 in method wrapper_CUDA_addmm)`

## Solution

This PR implements a fix for this