### PR TITLE
display module dtype and device

### DIFF
--- a/src/refiners/fluxion/layers/module.py
+++ b/src/refiners/fluxion/layers/module.py
@@ -164,6 +164,10 @@ class WeightedModule(Module):
     def dtype(self) -> DType:
         return self.weight.dtype
 
+    def __repr__(self) -> str:
+        str = super().__repr__()
+        return f"{str} [device={self.device}, dtype={self.dtype}]"
+
 
 class TreeNode(TypedDict):
     value: str
@@ -242,15 +246,6 @@ class ModuleTree:
                 value = f"({module._tag})"  # pyright: ignore[reportPrivateUsage]
             case (_, False):
                 value = f"({module._tag}) {module}"  # pyright: ignore[reportPrivateUsage]
-
-        dtype_str = getattr(module, "dtype", None).__repr__().replace("torch.", "")
-
-        if hasattr(module, "device") and module.device is not None:
-            device_str = f"{module.device.type}:{module.device.index}"
-        else:
-            device_str = "cpu"
-
-        value = f"{value} [dtype={dtype_str}, device={device_str}] "
 
         class_name = module.__class__.__name__
 

--- a/src/refiners/fluxion/layers/module.py
+++ b/src/refiners/fluxion/layers/module.py
@@ -164,9 +164,8 @@ class WeightedModule(Module):
     def dtype(self) -> DType:
         return self.weight.dtype
 
-    def __repr__(self) -> str:
-        str = super().__repr__()
-        return f"{str} [device={self.device}, dtype={self.dtype}]"
+    def __str__(self) -> str:
+        return f"{super().__str__().removesuffix(')')}, device={self.device}, dtype={str(self.dtype).removeprefix('torch.')})"
 
 
 class TreeNode(TypedDict):

--- a/src/refiners/fluxion/layers/module.py
+++ b/src/refiners/fluxion/layers/module.py
@@ -243,6 +243,15 @@ class ModuleTree:
             case (_, False):
                 value = f"({module._tag}) {module}"  # pyright: ignore[reportPrivateUsage]
 
+        dtype_str = getattr(module, "dtype", None).__repr__().replace("torch.", "")
+
+        if hasattr(module, "device") and module.device is not None:
+            device_str = f"{module.device.type}:{module.device.index}"
+        else:
+            device_str = "cpu"
+
+        value = f"{value} [dtype={dtype_str}, device={device_str}] "
+
         class_name = module.__class__.__name__
 
         node: TreeNode = {"value": value, "class_name": class_name, "children": []}


### PR DESCRIPTION
## Context

In the context of [#165](https://github.com/finegrain-ai/refiners/pull/165#issuecomment-1882887690), I'm splitting the training on different GPUs.

While doing this, I faced a lot of errors like `Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!`.

## Actual

The stack trace gives information about input tensor device allocation, but not any information about the module's device & dtype information.

## Expected

Print the device and the dtype of modules in the stack trace.