### PR TITLE
Use public url dataset in the configs/finetune-lora.toml

### DIFF
--- a/configs/finetune-lora.toml
+++ b/configs/finetune-lora.toml
@@ -50,8 +50,9 @@ dropout_probability = 0.2
 use_gyro_dropout = false
 
 [dataset]
-hf_repo = "acme/images"
+hf_repo = "1aurent/unsplash-lite-palette"
 revision = "main"
+caption_key = "ai_description"
 
 [checkpointing]
 # save_folder = "/path/to/ckpts"

--- a/configs/finetune-lora.toml
+++ b/configs/finetune-lora.toml
@@ -4,9 +4,9 @@ entity = "acme"
 project = "test-lora-training"
 
 [models]
-unet = {checkpoint = "/path/to/stable-diffusion-1-5/unet.safetensors"}
-text_encoder = {checkpoint = "/path/to/stable-diffusion-1-5/CLIPTextEncoderL.safetensors"}
-lda = {checkpoint = "/path/to/stable-diffusion-1-5/lda.safetensors"}
+unet = {checkpoint = "tests/weights/stable-diffusion-1-5/unet.safetensors"}
+text_encoder = {checkpoint = "tests/weights/stable-diffusion-1-5/CLIPTextEncoderL.safetensors"}
+lda = {checkpoint = "tests/weights/stable-diffusion-1-5/lda.safetensors"}
 
 [latent_diffusion]
 unconditional_sampling_probability = 0.05

--- a/scripts/training/finetune-ldm-textual-inversion.py
+++ b/scripts/training/finetune-ldm-textual-inversion.py
@@ -84,7 +84,7 @@ class TextualInversionDataset(TextEmbeddingLatentsDataset):
         )
         self.placeholder_token = self.config.textual_inversion.placeholder_token
 
-    def get_caption(self, index: int) -> str:
+    def get_caption(self, index: int, caption_key: str) -> str:
         # Ignore the dataset caption, if any: use a template instead
         return random.choice(self.templates).format(self.placeholder_token)
 

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -121,6 +121,9 @@ def image_to_tensor(image: Image.Image, device: Device | str | None = None, dtyp
 
     Values are clamped to the range `[0, 1]`.
     """
+    if image.mode == "P":
+        image = image.convert("RGB")
+
     image_tensor = torch.tensor(array(image).astype(float32) / 255.0, device=device, dtype=dtype)
 
     match image.mode:

--- a/src/refiners/training_utils/huggingface_datasets.py
+++ b/src/refiners/training_utils/huggingface_datasets.py
@@ -1,6 +1,6 @@
 from typing import Any, Generic, Protocol, TypeVar, cast
 
-from datasets import VerificationMode, load_dataset as _load_dataset  # type: ignore
+from datasets import DownloadManager, VerificationMode, load_dataset as _load_dataset  # type: ignore
 from pydantic import BaseModel  # type: ignore
 
 __all__ = ["load_hf_dataset", "HuggingfaceDataset"]
@@ -34,3 +34,4 @@ class HuggingfaceDatasetConfig(BaseModel):
     use_verification: bool = False
     resize_image_min_size: int = 512
     resize_image_max_size: int = 576
+    caption_key: str = "caption"

--- a/src/refiners/training_utils/latent_diffusion.py
+++ b/src/refiners/training_utils/latent_diffusion.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Callable, TypedDict, TypeVar
 
-from datasets import DownloadManager
+from datasets import DownloadManager # type: ignore
 from loguru import logger
 from PIL import Image
 from pydantic import BaseModel
@@ -59,6 +59,7 @@ class TextEmbeddingLatentsBatch:
 class CaptionImage(TypedDict):
     caption: str
     image: Image.Image
+    url: str
 
 
 ConfigType = TypeVar("ConfigType", bound=FinetuneLatentDiffusionConfig)
@@ -102,14 +103,14 @@ class TextEmbeddingLatentsDataset(Dataset[TextEmbeddingLatentsBatch]):
         return caption if random.random() > self.config.latent_diffusion.unconditional_sampling_probability else ""
 
     def get_caption(self, index: int, caption_key: str) -> str:
-        return self.dataset[index][caption_key]
+        return self.dataset[index][caption_key] # type: ignore
 
     def get_image(self, index: int) -> Image.Image:
         if "image" in self.dataset[index]:
             return self.dataset[index]["image"]
         elif "url" in self.dataset[index]:
-            url = self.dataset[index]["url"]
-            filename = self.download_manager.download(url)
+            url : str = self.dataset[index]["url"]
+            filename : str = self.download_manager.download(url) # type: ignore
             return Image.open(filename)
         else:
             raise RuntimeError(f"Dataset item at index [{index}] does not contain 'image' or 'url'")

--- a/src/refiners/training_utils/latent_diffusion.py
+++ b/src/refiners/training_utils/latent_diffusion.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Callable, TypedDict, TypeVar
 
-from datasets import DownloadManager # type: ignore
+from datasets import DownloadManager  # type: ignore
 from loguru import logger
 from PIL import Image
 from pydantic import BaseModel
@@ -103,14 +103,14 @@ class TextEmbeddingLatentsDataset(Dataset[TextEmbeddingLatentsBatch]):
         return caption if random.random() > self.config.latent_diffusion.unconditional_sampling_probability else ""
 
     def get_caption(self, index: int, caption_key: str) -> str:
-        return self.dataset[index][caption_key] # type: ignore
+        return self.dataset[index][caption_key]  # type: ignore
 
     def get_image(self, index: int) -> Image.Image:
         if "image" in self.dataset[index]:
             return self.dataset[index]["image"]
         elif "url" in self.dataset[index]:
-            url : str = self.dataset[index]["url"]
-            filename : str = self.download_manager.download(url) # type: ignore
+            url: str = self.dataset[index]["url"]
+            filename: str = self.download_manager.download(url)  # type: ignore
             return Image.open(filename)
         else:
             raise RuntimeError(f"Dataset item at index [{index}] does not contain 'image' or 'url'")


### PR DESCRIPTION
## Context

Related to https://github.com/finegrain-ai/refiners/pull/165#discussion_r1445967855
I'm trying to PR, little by little, my progress on #165

## Actual

The hf repo in the main branch in [config/finetune-lora.toml](https://github.com/finegrain-ai/refiners/blob/main/configs/finetune-lora.toml#L52C1-L54C18) are private repository.

It's not plug and play for a newcomer on the lib.

## Expected

The lib examples should work using public hf repository.

## Solution

I suggest to use https://huggingface.co/datasets/1aurent/unsplash-lite-palette for now, but we also need to make the latent_diffusion Trainer compatible with url datasets as discussed in  https://github.com/finegrain-ai/refiners/pull/165#discussion_r1445967855

NB: The current code is not optimized for pre-downloading or batch-downloading. 
The main purpose here is to make it work and keep it simple.
