### PR TITLE
List inputs in lda encode/decode, and clip text_encoder.

### DIFF
--- a/src/refiners/foundationals/clip/tokenizer.py
+++ b/src/refiners/foundationals/clip/tokenizer.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from itertools import islice
 from pathlib import Path
 
-from torch import Tensor, tensor
+from torch import Tensor, tensor, cat
 
 import refiners.fluxion.layers as fl
 from refiners.fluxion import pad
@@ -51,11 +51,20 @@ class CLIPTokenizer(fl.Module):
         self.end_of_text_token_id: int = end_of_text_token_id
         self.pad_token_id: int = pad_token_id
 
-    def forward(self, text: str) -> Tensor:
+    def forward(self, text: str | list[str]) -> Tensor:
+        
+        if isinstance(text, str):
+            return self.tokenize_str(text)
+        else:
+            assert isinstance(text, list), f"Expected type `str` or `list[str]`, got {type(text)}"
+            return cat([self.tokenize_str(txt) for txt in text])
+        
+    def tokenize_str(self, text: str) -> Tensor:
         tokens = self.encode(text=text, max_length=self.sequence_length).unsqueeze(dim=0)
+        
         assert (
             tokens.shape[1] <= self.sequence_length
-        ), f"Text is too long: tokens.shape[1] > sequence_length: {tokens.shape[1]} > {self.sequence_length}"
+        ), f"Text is too long: tokens.shape[1] > sequence_length: {tokens.shape[1]} > {self.sequence_length}, {len(text)}"
         return pad(x=tokens, pad=(0, self.sequence_length - tokens.shape[1]), value=self.pad_token_id)
 
     @lru_cache()

--- a/src/refiners/foundationals/latent_diffusion/multi_diffusion.py
+++ b/src/refiners/foundationals/latent_diffusion/multi_diffusion.py
@@ -83,7 +83,7 @@ class MultiDiffusion(Generic[T, D], ABC):
     def dtype(self) -> DType:
         return self.ldm.dtype
 
-    def decode_latents(self, x: Tensor) -> Image.Image:
+    def decode_latents(self, x: Tensor) -> Image.Image | list[Image.Image]:
         return self.ldm.lda.decode_latents(x=x)
 
     @staticmethod

--- a/src/refiners/foundationals/latent_diffusion/multi_diffusion.py
+++ b/src/refiners/foundationals/latent_diffusion/multi_diffusion.py
@@ -83,7 +83,7 @@ class MultiDiffusion(Generic[T, D], ABC):
     def dtype(self) -> DType:
         return self.ldm.dtype
 
-    def decode_latents(self, x: Tensor) -> Image.Image | list[Image.Image]:
+    def decode_latents(self, x: Tensor) -> Image.Image:
         return self.ldm.lda.decode_latents(x=x)
 
     @staticmethod

--- a/tests/foundationals/clip/test_text_encoder.py
+++ b/tests/foundationals/clip/test_text_encoder.py
@@ -101,3 +101,8 @@ def test_encoder(
     # numerical differences depending on the backend.
     # Also we use FP16 weights.
     assert (our_embeddings - ref_embeddings).abs().max() < 0.01
+    
+    # batched inputs
+    double_tokens = tokenizer([prompt, prompt[0:3]])
+    assert double_tokens.shape[0] == 2
+

--- a/tests/foundationals/latent_diffusion/test_auto_encoder.py
+++ b/tests/foundationals/latent_diffusion/test_auto_encoder.py
@@ -49,3 +49,11 @@ def test_encode_decode(encoder: LatentDiffusionAutoencoder, sample_image: Image.
     assert max(iter(decoded.getdata(band=1))) < 255  # type: ignore
 
     ensure_similar_images(sample_image, decoded, min_psnr=20, min_ssim=0.9)
+    
+    encoded = encoder.encode_images([sample_image, sample_image])
+    images = encoder.decode_images(encoded)
+    assert isinstance(images, list)
+    assert len(images) == 2
+    ensure_similar_images(sample_image, images[1], min_psnr=20, min_ssim=0.9)
+
+


### PR DESCRIPTION
Naming of `lda.decode_latents(latents)` feels strange cause `lda.decode(latents)` is also decoding latents.

I suggest using `lda.decode_image`/`lda.decode_images` and `lda.encode_image`/`lda.encode_images`

To not break examples, the current PR is keeping an alias `lda.decode_latents(latents) -> lda.decode_image(latents)` 