### PR TITLE
Add support for tests code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ wandb/
 
 # lock files
 requirements-dev.lock
+
+# coverage.py
+htmlcov/
+.coverage
+.coverage.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,15 @@ You can enforce running tests on CPU. Tests that require a GPU will be skipped.
 ```bash
 REFINERS_TEST_DEVICE=cpu rye run pytest
 ```
+
+You can collect [code coverage](https://github.com/nedbat/coveragepy) data while running tests with, e.g.:
+
+```bash
+rye run test-cov
+```
+
+Then, browse the corresponding HTML report with:
+
+```bash
+rye run serve-cov-report
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev-dependencies = [
     "docformatter>=1.7.5",
     "pytest>=7.4.2",
     "mkdocs-material>=9.5.3",
+    "coverage>=7.4.1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ line-length = 120
 [tool.ruff]
 src = ["src"] # see https://docs.astral.sh/ruff/settings/#src
 select = [
-  "I", # isort
+    "I", # isort
 ]
 ignore = [
     "F722", # forward-annotation-syntax-error, because of Jaxtyping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ allow-direct-references = true
 [tool.rye.scripts]
 lint = { chain = ["ruff format .", "ruff --fix ."] }
 serve-docs = "mkdocs serve"
+test-cov = "coverage run -m pytest"
+# Work around for "Couldn't parse" errors due to e.g. opencv-python:
+# https://github.com/nedbat/coveragepy/issues/1653
+build-html-cov = { cmd = "coverage html", env = { PYTHONWARNINGS = "ignore:Couldn't parse::coverage.report_core" } }
+serve-cov-report = { chain = ["build-html-cov", "python -m http.server 8080 -b 127.0.0.1 -d htmlcov"]}
 
 [tool.black]
 line-length = 120
@@ -99,3 +104,10 @@ include = ["src/refiners", "tests", "scripts"]
 strict = ["*"]
 exclude = ["**/__pycache__", "tests/weights"]
 reportMissingTypeStubs = "warning"
+
+[tool.coverage.run]
+branch = true
+
+# Also apply to HTML output, where appropriate
+[tool.coverage.report]
+ignore_errors = true # see `build-html-cov` for details

--- a/requirements.lock
+++ b/requirements.lock
@@ -5,6 +5,7 @@
 #   pre: false
 #   features: []
 #   all-features: true
+#   with-sources: false
 
 -e file:.
 aiohttp==3.9.1


### PR DESCRIPTION
E.g. usage:

    # Run tests with code coverage enabled
    # Optionally use pytest option, e.g. -k foo_bar, etc
    rye run test-cov
    # Browse the HTML report on http://127.0.0.1:8080/
    rye run serve-cov-report

Alternatively, see `rye run coverage --help` for advanced/custom use.