### PR TITLE
Configure and initialize mkdocstrings

### DIFF
--- a/docs/reference/SUMMARY.md
+++ b/docs/reference/SUMMARY.md
@@ -1,0 +1,12 @@
+* <code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Fluxion
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Adapters](fluxion/adapters.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Context](fluxion/context.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Layers](fluxion/layers.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Model Converter](fluxion/model_converter.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Utils](fluxion/utils.md)
+* <code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Foundationals Models
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> CLIP](foundationals/clip.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> DINOv2](foundationals/dinov2.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Latent Diffusion](foundationals/latent_diffusion.md)
+    * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Segment Anything](foundationals/segment_anything.md)
+

--- a/docs/reference/SUMMARY.md
+++ b/docs/reference/SUMMARY.md
@@ -4,7 +4,7 @@
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Layers](fluxion/layers.md)
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Model Converter](fluxion/model_converter.md)
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Utils](fluxion/utils.md)
-* <code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Foundationals Models
+* <code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Foundational Models
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> CLIP](foundationals/clip.md)
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> DINOv2](foundationals/dinov2.md)
     * [<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code> Latent Diffusion](foundationals/latent_diffusion.md)

--- a/docs/reference/fluxion/adapters.md
+++ b/docs/reference/fluxion/adapters.md
@@ -1,0 +1,1 @@
+::: refiners.fluxion.adapters

--- a/docs/reference/fluxion/context.md
+++ b/docs/reference/fluxion/context.md
@@ -1,0 +1,1 @@
+::: refiners.fluxion.context

--- a/docs/reference/fluxion/layers.md
+++ b/docs/reference/fluxion/layers.md
@@ -1,0 +1,1 @@
+::: refiners.fluxion.layers

--- a/docs/reference/fluxion/model_converter.md
+++ b/docs/reference/fluxion/model_converter.md
@@ -1,0 +1,1 @@
+::: refiners.fluxion.model_converter

--- a/docs/reference/fluxion/utils.md
+++ b/docs/reference/fluxion/utils.md
@@ -1,0 +1,1 @@
+::: refiners.fluxion.utils

--- a/docs/reference/foundationals/clip.md
+++ b/docs/reference/foundationals/clip.md
@@ -1,0 +1,1 @@
+::: refiners.foundationals.clip

--- a/docs/reference/foundationals/dinov2.md
+++ b/docs/reference/foundationals/dinov2.md
@@ -1,0 +1,1 @@
+::: refiners.foundationals.dinov2

--- a/docs/reference/foundationals/latent_diffusion.md
+++ b/docs/reference/foundationals/latent_diffusion.md
@@ -1,0 +1,1 @@
+::: refiners.foundationals.latent_diffusion

--- a/docs/reference/foundationals/segment_anything.md
+++ b/docs/reference/foundationals/segment_anything.md
@@ -1,0 +1,1 @@
+::: refiners.foundationals.segment_anything

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,13 +19,34 @@ theme:
     - navigation.expand
     - navigation.path
     - toc.follow
-    - toc.integrate
     - navigation.tabs.sticky
     - content.code.copy
 plugins:
-  - mkdocstrings
   - search
   - tags
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - mkdocstrings:
+      handlers:
+        python:
+          import:
+            - https://docs.python.org/3/objects.inv
+            - https://pytorch.org/docs/master/objects.inv
+          options:
+            show_bases: true
+            show_source: true
+            show_root_toc_entry: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_if_no_docstring: false
+            filters:
+              - "!^_"
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
 extra_css:
   - stylesheets/extra.css
 nav:
@@ -39,7 +60,7 @@ nav:
     - concepts/index.md
     - concepts/adapters.md
   - API Reference:
-      - index.md
+      - Refiners: reference/
 extra:
   social:
     - icon: fontawesome/brands/discord

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,10 @@ dev-dependencies = [
     "ruff>=0.1.15",
     "docformatter>=1.7.5",
     "pytest>=8.0.0",
-    "mkdocs-material>=9.5.6",
     "coverage>=7.4.1",
+    "mkdocs-material>=9.5.6",
     "mkdocstrings[python]>=0.24.0",
+    "mkdocs-literate-nav>=0.6.1",
 ]
 
 
@@ -71,7 +72,10 @@ test-cov = "coverage run -m pytest"
 # Work around for "Couldn't parse" errors due to e.g. opencv-python:
 # https://github.com/nedbat/coveragepy/issues/1653
 build-html-cov = { cmd = "coverage html", env = { PYTHONWARNINGS = "ignore:Couldn't parse::coverage.report_core" } }
-serve-cov-report = { chain = ["build-html-cov", "python -m http.server 8080 -b 127.0.0.1 -d htmlcov"]}
+serve-cov-report = { chain = [
+    "build-html-cov",
+    "python -m http.server 8080 -b 127.0.0.1 -d htmlcov",
+] }
 
 [tool.black]
 line-length = 120

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,3 +1,4 @@
 mkdocs-material==9.5.3
 mkdocstrings==0.24.0
 mkdocstrings-python==1.8.0
+mkdocs-literate-nav==0.6.1


### PR DESCRIPTION
- Set a bunch of `mkdocstrings` options
- Remove `toc.integrate` theme feature
- Setup `literate-nav` plugin