### PR TITLE
docs: add missing CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+refine.rs


### PR DESCRIPTION
Was set part of the workflow before #230