### PR TITLE
pyproject.toml: add some PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,16 @@ dependencies = [
 ]
 readme = "README.md"
 requires-python = ">= 3.10"
+classifiers = [
+  "Typing :: Typed",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "License :: OSI Approved :: MIT License"
+]
 
 [project.optional-dependencies]
 training = [


### PR DESCRIPTION
In particuler, the Python versions (3.10, etc) used to be included with builds created with Poetry (they got removed after the switch to Rye: see #141). This commit should fix the broken pypi badge.

Note: these classifiers are not exhaustive. New ones will most probably be added in the future.