### PR TITLE
batch inputs for compute_clip_text_embedding

### DIFF
--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/model.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/model.py
@@ -65,7 +65,9 @@ class StableDiffusion_XL(LatentDiffusionModel):
             dtype=dtype,
         )
 
-    def compute_clip_text_embedding(self, text: str, negative_text: str | None = None) -> tuple[Tensor, Tensor]:
+    def compute_clip_text_embedding(
+        self, text: str | list[str], negative_text: str | list[str] = ""
+    ) -> tuple[Tensor, Tensor]:
         """Compute the CLIP text embedding associated with the given prompt and negative prompt.
 
         Args:
@@ -73,14 +75,13 @@ class StableDiffusion_XL(LatentDiffusionModel):
             negative_text: The negative prompt to compute the CLIP text embedding of.
                 If not provided, the negative prompt is assumed to be empty (i.e., `""`).
         """
-        conditional_embedding, conditional_pooled_embedding = self.clip_text_encoder(text)
-        if text == negative_text:
-            return torch.cat(tensors=(conditional_embedding, conditional_embedding), dim=0), torch.cat(
-                tensors=(conditional_pooled_embedding, conditional_pooled_embedding), dim=0
-            )
 
-        # TODO: when negative_text is None, use zero tensor?
-        negative_embedding, negative_pooled_embedding = self.clip_text_encoder(negative_text or "")
+        text = [text] if isinstance(text, str) else text
+        negative_text = [negative_text] if isinstance(negative_text, str) else negative_text
+        assert len(text) == len(negative_text), "The length of the text list and negative_text should be the same"
+
+        conditional_embedding, conditional_pooled_embedding = self.clip_text_encoder(text)
+        negative_embedding, negative_pooled_embedding = self.clip_text_encoder(negative_text)
 
         return torch.cat(tensors=(negative_embedding, conditional_embedding), dim=0), torch.cat(
             tensors=(negative_pooled_embedding, conditional_pooled_embedding), dim=0

--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/text_encoder.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/text_encoder.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from jaxtyping import Float
-from torch import Tensor, cat, device as Device, dtype as DType
+from torch import Tensor, cat, device as Device, dtype as DType, split
 
 import refiners.fluxion.layers as fl
 from refiners.fluxion.adapters.adapter import Adapter
@@ -40,7 +40,7 @@ class TextEncoderWithPooling(fl.Chain, Adapter[CLIPTextEncoderG]):
     def init_context(self) -> Contexts:
         return {"text_encoder_pooling": {"end_of_text_index": []}}
 
-    def __call__(self, text: str) -> tuple[Float[Tensor, "1 77 1280"], Float[Tensor, "1 1280"]]:
+    def __call__(self, text: str | list[str]) -> tuple[Float[Tensor, "batch 77 1280"], Float[Tensor, "batch 1280"]]:
         return super().__call__(text)
 
     @property
@@ -48,13 +48,14 @@ class TextEncoderWithPooling(fl.Chain, Adapter[CLIPTextEncoderG]):
         return self.ensure_find(CLIPTokenizer)
 
     def set_end_of_text_index(self, end_of_text_index: list[int], tokens: Tensor) -> None:
-        position = (tokens == self.tokenizer.end_of_text_token_id).nonzero(as_tuple=True)[1].item()
-        end_of_text_index.append(cast(int, position))
+        for str_tokens in split(tokens, 1):
+            position = (str_tokens == self.tokenizer.end_of_text_token_id).nonzero(as_tuple=True)[1].item()  # type: ignore
+            end_of_text_index.append(cast(int, position))
 
-    def pool(self, x: Float[Tensor, "1 77 1280"]) -> Float[Tensor, "1 1280"]:
+    def pool(self, x: Float[Tensor, "batch 77 1280"]) -> Float[Tensor, "batch 1280"]:
         end_of_text_index = self.use_context(context_name="text_encoder_pooling").get("end_of_text_index", [])
-        assert len(end_of_text_index) == 1, "End of text index not found."
-        return x[:, end_of_text_index[0], :]
+        assert len(end_of_text_index) == x.shape[0], "End of text index not found."
+        return cat([x[i : i + 1, end_of_text_index[i], :] for i in range(x.shape[0])], dim=0)
 
 
 class DoubleTextEncoder(fl.Chain):
@@ -75,7 +76,7 @@ class DoubleTextEncoder(fl.Chain):
         tep = TextEncoderWithPooling(target=text_encoder_g, projection=projection)
         tep.inject(self.layer("Parallel", fl.Parallel))
 
-    def __call__(self, text: str) -> tuple[Float[Tensor, "1 77 2048"], Float[Tensor, "1 1280"]]:
+    def __call__(self, text: str | list[str]) -> tuple[Float[Tensor, "batch 77 2048"], Float[Tensor, "batch 1280"]]:
         return super().__call__(text)
 
     def concatenate_embeddings(

--- a/tests/foundationals/latent_diffusion/test_sdxl_double_encoder.py
+++ b/tests/foundationals/latent_diffusion/test_sdxl_double_encoder.py
@@ -100,3 +100,24 @@ def test_double_text_encoder(diffusers_sdxl: DiffusersSDXL, double_text_encoder:
 
     assert torch.allclose(input=negative_double_embedding, other=negative_prompt_embeds, rtol=1e-3, atol=1e-3)
     assert torch.allclose(input=negative_pooled_embedding, other=negative_pooled_prompt_embeds, rtol=1e-3, atol=1e-3)
+
+
+@no_grad()
+def test_double_text_encoder_batch2(double_text_encoder: DoubleTextEncoder) -> None:
+    manual_seed(seed=0)
+    prompt1 = "A photo of a pizza."
+    prompt2 = "A giant duck."
+
+    double_embedding_b2, pooled_embedding_b2 = double_text_encoder([prompt1, prompt2])
+
+    assert double_embedding_b2.shape == torch.Size([2, 77, 2048])
+    assert pooled_embedding_b2.shape == torch.Size([2, 1280])
+
+    double_embedding_1, pooled_embedding_1 = double_text_encoder(prompt1)
+    double_embedding_2, pooled_embedding_2 = double_text_encoder(prompt2)
+
+    assert torch.allclose(input=double_embedding_1, other=double_embedding_b2[0:1], rtol=1e-3, atol=1e-3)
+    assert torch.allclose(input=pooled_embedding_1, other=pooled_embedding_b2[0:1], rtol=1e-3, atol=1e-3)
+
+    assert torch.allclose(input=double_embedding_2, other=double_embedding_b2[1:2], rtol=1e-3, atol=1e-3)
+    assert torch.allclose(input=pooled_embedding_2, other=pooled_embedding_b2[1:2], rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Context

I need this for #165, to do GPU efficient evaluation (batch_size > 1).
This is the extension of #213 
This is also a baby step in the context of #255 @limiteinductive 

### One question

In `compute_clip_image_embedding` there is a `concat_batches` bool, i'm shared if we need to put it in `compute_clip_text_embedding` or not.

2 contradictory POV
* I did not put it now cause the functionnal use case is not clear, 
* For convergence of inputs formats (in the context of #255 SD refactoring), we might want to tend to uniformity here.
