### PR TITLE
do not regenerate lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: rye sync
         if: steps.changes.outputs.sources == 'true'
-        run: rye sync --all-features
+        run: rye sync --no-lock --all-features
 
       - name: ruff format
         if: steps.changes.outputs.sources == 'true'


### PR DESCRIPTION
speedup installation by not generating lock files