### PR TITLE
test_trainer: use `model_copy` instead of `copy`

### DIFF
--- a/tests/training_utils/test_trainer.py
+++ b/tests/training_utils/test_trainer.py
@@ -82,7 +82,7 @@ def mock_trainer(mock_config: MockConfig) -> MockTrainer:
 
 @pytest.fixture
 def mock_trainer_short(mock_config: MockConfig) -> MockTrainer:
-    mock_config_short = mock_config.copy()
+    mock_config_short = mock_config.model_copy(deep=True)
     mock_config_short.training.duration = {"number": 3, "unit": TimeUnit.STEP}
     return MockTrainer(config=mock_config_short)
 


### PR DESCRIPTION
The `copy` method has been deprecated.