### PR TITLE
Add bias/use_bias to LinearLora/Conv2dLora for API convergence with Linear/Conv2d

### DIFF
--- a/src/refiners/fluxion/adapters/lora.py
+++ b/src/refiners/fluxion/adapters/lora.py
@@ -191,6 +191,7 @@ class LinearLora(Lora[fl.Linear]):
         out_features: int,
         rank: int = 16,
         scale: float = 1.0,
+        bias: bool = False,
         device: Device | str | None = None,
         dtype: DType | None = None,
     ) -> None:
@@ -207,6 +208,7 @@ class LinearLora(Lora[fl.Linear]):
         """
         self.in_features = in_features
         self.out_features = out_features
+        self.bias = bias
 
         super().__init__(
             name,
@@ -251,7 +253,7 @@ class LinearLora(Lora[fl.Linear]):
             fl.Linear(
                 in_features=self.rank,
                 out_features=self.out_features,
-                bias=False,
+                bias=self.bias,
                 device=device,
                 dtype=dtype,
             ),
@@ -282,6 +284,7 @@ class Conv2dLora(Lora[fl.Conv2d]):
         kernel_size: tuple[int, int] = (1, 3),
         stride: tuple[int, int] = (1, 1),
         padding: tuple[int, int] = (0, 1),
+        use_bias: bool = False,
         device: Device | str | None = None,
         dtype: DType | None = None,
     ) -> None:
@@ -304,6 +307,7 @@ class Conv2dLora(Lora[fl.Conv2d]):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.use_bias = use_bias
 
         super().__init__(
             name,
@@ -360,7 +364,7 @@ class Conv2dLora(Lora[fl.Conv2d]):
                 kernel_size=self.kernel_size[1],
                 stride=self.stride[1],
                 padding=self.padding[1],
-                use_bias=False,
+                use_bias=self.use_bias,
                 device=device,
                 dtype=dtype,
             ),

--- a/tests/adapters/test_lora.py
+++ b/tests/adapters/test_lora.py
@@ -21,7 +21,7 @@ def test_properties(lora: LinearLora, conv_lora: Conv2dLora) -> None:
     assert lora.scale == 1.0
     assert lora.in_features == lora.down.in_features == 320
     assert lora.out_features == lora.up.out_features == 128
-
+    assert lora.bias == False
     assert conv_lora.name == "conv_test"
     assert conv_lora.rank == conv_lora.down.out_channels == conv_lora.up.in_channels == 4
     assert conv_lora.scale == 1.0
@@ -30,6 +30,7 @@ def test_properties(lora: LinearLora, conv_lora: Conv2dLora) -> None:
     assert conv_lora.kernel_size == (conv_lora.down.kernel_size[0], conv_lora.up.kernel_size[0]) == (3, 1)
     # padding is set so the spatial dimensions are preserved
     assert conv_lora.padding == (conv_lora.down.padding[0], conv_lora.up.padding[0]) == (0, 1)
+    assert conv_lora.use_bias == False
 
 
 def test_scale_setter(lora: LinearLora) -> None:


### PR DESCRIPTION
## Context

Still working on #165 

Want to explore the lora/non-lora in the cross-attention adapter and to replace, conditionnaly 

```python
fl.Linear(
  ...
  bias=text_cross_attention.use_bias
)
```

with 

```python
fl.LinearLora(
  ...
  bias=text_cross_attention.use_bias
)
```

## Remarks

* impacted also `Conv2DLora` for coherence
* Default values are `False`/`False` for Lora and `True/True` for non-Lora layers, i feel it makes sense considering bias on LinearLora is not the rule
* bias only impact the second lora layer, first lora layer bias are non-relevant on my POV

