### PR TITLE
BaseBatch : easily manipulate batched list & tensors

### DIFF
--- a/src/refiners/training_utils/__init__.py
+++ b/src/refiners/training_utils/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import requires
 
 from packaging.requirements import Requirement
 
+from refiners.training_utils.batch import BaseBatch
 from refiners.training_utils.callback import Callback, CallbackConfig
 from refiners.training_utils.clock import ClockConfig
 from refiners.training_utils.config import (
@@ -18,7 +19,6 @@ from refiners.training_utils.config import (
 from refiners.training_utils.gradient_clipping import GradientClippingConfig
 from refiners.training_utils.trainer import Trainer, register_callback, register_model
 from refiners.training_utils.wandb import WandbConfig, WandbMixin
-from refiners.training_utils.batch import BaseBatch
 
 refiners_requires = requires("refiners")
 assert refiners_requires is not None
@@ -56,5 +56,5 @@ __all__ = [
     "GradientClippingConfig",
     "Optimizers",
     "LRSchedulerType",
-    "BaseBatch"
+    "BaseBatch",
 ]

--- a/src/refiners/training_utils/__init__.py
+++ b/src/refiners/training_utils/__init__.py
@@ -18,6 +18,7 @@ from refiners.training_utils.config import (
 from refiners.training_utils.gradient_clipping import GradientClippingConfig
 from refiners.training_utils.trainer import Trainer, register_callback, register_model
 from refiners.training_utils.wandb import WandbConfig, WandbMixin
+from refiners.training_utils.batch import BaseBatch
 
 refiners_requires = requires("refiners")
 assert refiners_requires is not None
@@ -55,4 +56,5 @@ __all__ = [
     "GradientClippingConfig",
     "Optimizers",
     "LRSchedulerType",
+    "BaseBatch"
 ]

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -1,7 +1,9 @@
 from pathlib import Path
-from typing import Any, Type, TypeVar, get_origin, get_type_hints
+from typing import Any, Type, TypeVar, cast, get_origin, get_type_hints
 
 from torch import Tensor, cat, device as Device, dtype as DType, load as torch_load, save as torch_save  # type: ignore
+
+from refiners.fluxion.utils import summarize_tensor  # type: ignore
 
 T = TypeVar("T", bound="BaseBatch")
 
@@ -20,54 +22,57 @@ class TypeCheckMeta(type):
         if new_class.__name__ == "BaseBatch":
             return new_class
 
-        hints = get_type_hints(new_class)
-        if len(hints) == 0:
+        type_hints = get_type_hints(new_class)
+        if len(type_hints) == 0:
             raise ValueError(f"At least one attribute with type hint is required for {new_class.__name__}")
 
-        for attr, hint in hints.items():
-            if not simple_hint(hint) in [Tensor, list]:
-                raise TypeError(f"Type of '{attr}' must be Tensor or list, got {hint}")
+        for attr_key, attr_hint in type_hints.items():
+            if not simple_hint(attr_hint) in [Tensor, list]:
+                raise TypeError(f"Type of '{attr_key}' must be Tensor or list, got {attr_hint}")
         return new_class
 
 
+AttrType = Tensor | list[Any]
+
+
 class BaseBatch(metaclass=TypeCheckMeta):
-    def __init__(self, **kwargs: Tensor | list[Any]):
+    def __init__(self, **kwargs: AttrType):
         type_hints = get_type_hints(self.__class__)
 
         size = None
 
-        for key in kwargs:
-            if key not in type_hints:
-                raise ValueError(f"Attribute '{key}' is not valid")
+        for arg_key in kwargs:
+            if arg_key not in type_hints:
+                raise ValueError(f"Attribute '{arg_key}' is not valid")
 
-        for key in type_hints:
-            type_hint = type_hints[key]
+        for type_key in type_hints:
+            type_hint = type_hints[type_key]
 
-            if key not in kwargs:
-                raise ValueError(f"Missing required attribute '{key}'")
+            if type_key not in kwargs:
+                raise ValueError(f"Missing required attribute '{type_key}'")
 
-            value = kwargs[key]
+            arg_value = kwargs[type_key]
 
-            s_hint = simple_hint(type_hint)
-            if not isinstance(value, s_hint):
+            simple_type_hint = simple_hint(type_hint)
+            if not isinstance(arg_value, simple_type_hint):
                 raise TypeError(
-                    f"Invalid type for attribute '{key}': Expected {s_hint.__name__}, got {type(value).__name__}"
+                    f"Invalid type for attribute '{type_key}': Expected {simple_type_hint.__name__}, got {type(arg_value).__name__}"
                 )
 
-            if isinstance(value, list):
-                new_size = len(value)
+            if isinstance(arg_value, list):
+                new_size = len(arg_value)
             else:
-                new_size = value.shape[0]
+                new_size = arg_value.shape[0]
 
             if new_size == 0:
-                raise ValueError(f"Attribute '{key}' is empty, empty attributes are not permitted")
+                raise ValueError(f"Attribute '{type_key}' is empty, empty attributes are not permitted")
 
             if size is not None and size != new_size:
-                raise ValueError(f"Attribute '{key}' has size {new_size}, expected {size}")
+                raise ValueError(f"Attribute '{type_key}' has size {new_size}, expected {size}")
 
             size = new_size
 
-            setattr(self, key, kwargs[key])
+            setattr(self, type_key, kwargs[type_key])
 
         if size is None:
             raise ValueError(f"Empty batch is not valid")
@@ -84,13 +89,13 @@ class BaseBatch(metaclass=TypeCheckMeta):
         if l == 0:
             raise ValueError(f"Cannot collate an empty list of {cls.__name__}")
 
-        for key in type_hints.keys():
-            attr_list = [getattr(obj, key) for obj in batch_list]
+        for type_key in type_hints.keys():
+            attr_list = [getattr(obj, type_key) for obj in batch_list]
 
             if isinstance(attr_list[0], Tensor):
-                collated_attrs[key] = cat(tensors=tuple(attr_list), dim=0)
+                collated_attrs[type_key] = cat(tensors=tuple(attr_list), dim=0)
             elif isinstance(attr_list[0], list):
-                collated_attrs[key] = [item for sublist in attr_list for item in sublist]
+                collated_attrs[type_key] = [item for sublist in attr_list for item in sublist]
             else:
                 raise ValueError(f"Unsupported attribute type for collation: {type(attr_list[0])}")
 
@@ -98,12 +103,12 @@ class BaseBatch(metaclass=TypeCheckMeta):
         return collated_instance
 
     def to(self: T, device: Device | None = None, dtype: DType | None = None) -> T:
-        for key in get_type_hints(self.__class__):
-            value = getattr(self, key)
+        for type_key in get_type_hints(self.__class__):
+            value = getattr(self, type_key)
             if isinstance(value, Tensor):
-                setattr(self, key, value.to(device, dtype))
+                setattr(self, type_key, value.to(device, dtype))
             elif isinstance(value, list):
-                setattr(self, key, value)
+                setattr(self, type_key, value)
             else:
                 raise ValueError(f"Unsupported attribute type for to: {type(value)}")
         return self
@@ -111,14 +116,14 @@ class BaseBatch(metaclass=TypeCheckMeta):
     def __len__(self) -> int:
         return self._length
 
-    def to_dict(self):
-        return {attr: getattr(self, attr) for attr in get_type_hints(self.__class__)}
+    def to_dict(self) -> dict[str, AttrType]:
+        return {type_key: getattr(self, type_key) for type_key in get_type_hints(self.__class__)}
 
     def split(self: T) -> list[T]:
         result: list[T] = []
         l = len(self)
         for i in range(l):
-            args = {key: getattr(self, key)[i : i + 1] for key in get_type_hints(self.__class__)}
+            args = {type_key: getattr(self, type_key)[i : i + 1] for type_key in get_type_hints(self.__class__)}
             result.append(self.__class__(**args))
         return result
 
@@ -127,8 +132,8 @@ class BaseBatch(metaclass=TypeCheckMeta):
             yield batch
 
     @classmethod
-    def load(cls: Type[T], filename: Path) -> T:
-        return cls(**torch_load(filename, map_location="cpu"))
+    def load(cls: Type[T], filename: Path, map_location: Device | None = None) -> T:
+        return cls(**torch_load(filename, map_location=map_location))
 
     def save(self, filename: Path) -> None:
         torch_save(self.to_dict(), filename)
@@ -144,7 +149,9 @@ class BaseBatch(metaclass=TypeCheckMeta):
 
         for key in dict:
             if isinstance(dict[key], Tensor):
-                if not (dict[key] == other_dict[key]).all():
+                condition = dict[key] == other_dict[key]
+                casted = cast(Tensor, condition)
+                if not casted.all():
                     return False
             else:
                 if dict[key] != other_dict[key]:
@@ -154,5 +161,34 @@ class BaseBatch(metaclass=TypeCheckMeta):
     def __neq__(self, __value: object) -> bool:
         return not self.__eq__(__value)
 
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}({len(self)})"
+    def __repr__(self) -> str:
+        attr_strs: list[str] = []
+        for type_key in get_type_hints(self.__class__):
+            attr_value = getattr(self, type_key)
+            if isinstance(attr_value, list):
+                attr_strs.append(f"{type_key}={attr_value}")
+            else:
+                attr_strs.append(f"{type_key}={summarize_tensor(attr_value)}")
+        return f"{self.__class__.__name__}({len(self)})[{','.join(attr_strs)}]"
+
+    def __getitem__(self: T, key: slice | int | list[int] | list[bool]) -> T:
+        if isinstance(key, slice):
+            return self.__class__(
+                **{type_key: getattr(self, type_key)[key] for type_key in get_type_hints(self.__class__)}
+            )
+        elif isinstance(key, int):
+            return self[key : key + 1]
+        else:  # list
+            if len(key) == 0:
+                raise ValueError("Empty list is not valid")
+            if isinstance(key[0], bool):
+                if len(key) != len(self):
+                    raise ValueError("Boolean list must have the same length as the batch")
+                indices: list[int] = list(filter(lambda x: key[x], range(len(self))))
+                if len(indices) == 0:
+                    raise ValueError("Boolean list must have at least one true value")
+                return self[indices]
+            else:  # list[int]
+                indices = cast(list[int], key)
+                batch_list: list[T] = [self[i] for i in indices]
+                return self.__class__.collate(batch_list)

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import Any, Type, TypeVar, cast, dataclass_transform, get_origin, get_type_hints
+from typing import Any, Type, TypeVar, cast, get_origin, get_type_hints
 
 from torch import Tensor, cat, device as Device, dtype as DType, load as torch_load, save as torch_save  # type: ignore
+from typing_extensions import dataclass_transform
 
 from refiners.fluxion.utils import summarize_tensor  # type: ignore
 

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -1,83 +1,89 @@
-from math import e
-from typing import Type, TypeVar, get_type_hints, get_origin, cast
-import attr
-
-from torch import Tensor, cat, device as Device, dtype as DType, empty, stack
 from pathlib import Path
-from torch import load as torch_load, save as torch_save
-T = TypeVar('T', bound='BaseBatch')
+from typing import Any, Type, TypeVar, get_origin, get_type_hints
 
-def simple_hint(hint: Type) -> Type:
+from torch import Tensor, cat, device as Device, dtype as DType, load as torch_load, save as torch_save  # type: ignore
+
+T = TypeVar("T", bound="BaseBatch")
+
+
+def simple_hint(hint: Type[Any]) -> Type[Any]:
     origin = get_origin(hint)
-    if origin is None: # for Tensor
+    if origin is None:  # for Tensor
         return hint
     return origin
 
+
 class TypeCheckMeta(type):
-    def __new__(cls, name, bases, dct):
+    def __new__(cls, name: str, bases: tuple[type, ...], dct: dict[str, Any]) -> type:
         new_class = super().__new__(cls, name, bases, dct)
-        
+
         if new_class.__name__ == "BaseBatch":
             return new_class
-        
+
         hints = get_type_hints(new_class)
         if len(hints) == 0:
             raise ValueError(f"At least one attribute with type hint is required for {new_class.__name__}")
-        
+
         for attr, hint in hints.items():
             if not simple_hint(hint) in [Tensor, list]:
-                raise TypeError(f"Type of {attr} must be Tensor or list, got {hint}")
+                raise TypeError(f"Type of '{attr}' must be Tensor or list, got {hint}")
         return new_class
 
-class BaseBatch(metaclass=TypeCheckMeta):
-    
-    def __init__(self, **kwargs):
 
+class BaseBatch(metaclass=TypeCheckMeta):
+    def __init__(self, **kwargs: Tensor | list[Any]):
         type_hints = get_type_hints(self.__class__)
 
         size = None
+
+        for key in kwargs:
+            if key not in type_hints:
+                raise ValueError(f"Attribute '{key}' is not valid")
 
         for key in type_hints:
             type_hint = type_hints[key]
 
             if key not in kwargs:
-                raise ValueError(f"Missing required attribute: {key} in {kwargs}")
+                raise ValueError(f"Missing required attribute '{key}'")
 
             value = kwargs[key]
-            
+
             s_hint = simple_hint(type_hint)
             if not isinstance(value, s_hint):
-                raise ValueError(f"Invalid type for attribute {key}: Expected {s_hint}, got {type(value)}")
-            
+                raise TypeError(
+                    f"Invalid type for attribute '{key}': Expected {s_hint.__name__}, got {type(value).__name__}"
+                )
+
             if isinstance(value, list):
                 new_size = len(value)
-            elif isinstance(value, Tensor):
-                new_size = value.shape[0]
             else:
-                raise ValueError(f"Unsupported attribute type for '{key}': '{type(value)}', should be list or Tensor.")
+                new_size = value.shape[0]
+
+            if new_size == 0:
+                raise ValueError(f"Attribute '{key}' is empty, empty attributes are not permitted")
 
             if size is not None and size != new_size:
-                raise ValueError(f"Attribute {key} has size {new_size}, expected {size}")
-            
+                raise ValueError(f"Attribute '{key}' has size {new_size}, expected {size}")
+
             size = new_size
 
             setattr(self, key, kwargs[key])
-        
+
         if size is None:
-            raise ValueError(f"Size of the batch cannot be None")
-        
+            raise ValueError(f"Empty batch is not valid")
+
         self._length = size
 
     @classmethod
     def collate(cls: Type[T], batch_list: list[T]) -> T:
-        collated_attrs = {}
+        collated_attrs: dict[str, Any] = {}
         type_hints = get_type_hints(cls)
-        
+
         l = len(batch_list)
-        
+
         if l == 0:
             raise ValueError(f"Cannot collate an empty list of {cls.__name__}")
-        
+
         for key in type_hints.keys():
             attr_list = [getattr(obj, key) for obj in batch_list]
 
@@ -87,10 +93,10 @@ class BaseBatch(metaclass=TypeCheckMeta):
                 collated_attrs[key] = [item for sublist in attr_list for item in sublist]
             else:
                 raise ValueError(f"Unsupported attribute type for collation: {type(attr_list[0])}")
-            
+
         collated_instance = cls(**collated_attrs)
         return collated_instance
-    
+
     def to(self: T, device: Device | None = None, dtype: DType | None = None) -> T:
         for key in get_type_hints(self.__class__):
             value = getattr(self, key)
@@ -101,31 +107,52 @@ class BaseBatch(metaclass=TypeCheckMeta):
             else:
                 raise ValueError(f"Unsupported attribute type for to: {type(value)}")
         return self
-    
+
     def __len__(self) -> int:
         return self._length
-    
+
     def to_dict(self):
         return {attr: getattr(self, attr) for attr in get_type_hints(self.__class__)}
-    
+
     def split(self: T) -> list[T]:
-        result : list[T] = []
+        result: list[T] = []
         l = len(self)
         for i in range(l):
-            args = {key: getattr(self, key)[i:i+1] for key in get_type_hints(self.__class__)}
+            args = {key: getattr(self, key)[i : i + 1] for key in get_type_hints(self.__class__)}
             result.append(self.__class__(**args))
         return result
 
     def __iter__(self):
         for batch in self.split():
             yield batch
-    
+
     @classmethod
     def load(cls: Type[T], filename: Path) -> T:
-        return cls(**torch_load(filename, map_location='cpu'))
-    
+        return cls(**torch_load(filename, map_location="cpu"))
+
     def save(self, filename: Path) -> None:
         torch_save(self.to_dict(), filename)
 
     def clone(self: T) -> T:
         return self.__class__(**self.to_dict())
+
+    def __eq__(self, __value: object) -> bool:
+        if not isinstance(__value, self.__class__):
+            return False
+        dict = self.to_dict()
+        other_dict = __value.to_dict()
+
+        for key in dict:
+            if isinstance(dict[key], Tensor):
+                if not (dict[key] == other_dict[key]).all():
+                    return False
+            else:
+                if dict[key] != other_dict[key]:
+                    return False
+        return True
+
+    def __neq__(self, __value: object) -> bool:
+        return not self.__eq__(__value)
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}({len(self)})"

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -127,11 +127,9 @@ class BaseBatch(metaclass=TypeCheckMeta):
     def to(self: T, device: Device | None = None, dtype: DType | None = None) -> T:
         attr_types = self.__class__.attr_types()
         for attr_name, attr_type in attr_types.items():
-            value = getattr(self, attr_name)
             if attr_type == Tensor:
-                setattr(self, attr_name, value.to(device, dtype))
-            else:
-                setattr(self, attr_name, value)
+                value = cast(Tensor, self.__getattr__(attr_name))
+                self.__setattr__(attr_name, value.to(device, dtype))
 
         return self
 

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -1,0 +1,131 @@
+from math import e
+from typing import Type, TypeVar, get_type_hints, get_origin, cast
+import attr
+
+from torch import Tensor, cat, device as Device, dtype as DType, empty, stack
+from pathlib import Path
+from torch import load as torch_load, save as torch_save
+T = TypeVar('T', bound='BaseBatch')
+
+def simple_hint(hint: Type) -> Type:
+    origin = get_origin(hint)
+    if origin is None: # for Tensor
+        return hint
+    return origin
+
+class TypeCheckMeta(type):
+    def __new__(cls, name, bases, dct):
+        new_class = super().__new__(cls, name, bases, dct)
+        
+        if new_class.__name__ == "BaseBatch":
+            return new_class
+        
+        hints = get_type_hints(new_class)
+        if len(hints) == 0:
+            raise ValueError(f"At least one attribute with type hint is required for {new_class.__name__}")
+        
+        for attr, hint in hints.items():
+            if not simple_hint(hint) in [Tensor, list]:
+                raise TypeError(f"Type of {attr} must be Tensor or list, got {hint}")
+        return new_class
+
+class BaseBatch(metaclass=TypeCheckMeta):
+    
+    def __init__(self, **kwargs):
+
+        type_hints = get_type_hints(self.__class__)
+
+        size = None
+
+        for key in type_hints:
+            type_hint = type_hints[key]
+
+            if key not in kwargs:
+                raise ValueError(f"Missing required attribute: {key} in {kwargs}")
+
+            value = kwargs[key]
+            
+            s_hint = simple_hint(type_hint)
+            if not isinstance(value, s_hint):
+                raise ValueError(f"Invalid type for attribute {key}: Expected {s_hint}, got {type(value)}")
+            
+            if isinstance(value, list):
+                new_size = len(value)
+            elif isinstance(value, Tensor):
+                new_size = value.shape[0]
+            else:
+                raise ValueError(f"Unsupported attribute type for '{key}': '{type(value)}', should be list or Tensor.")
+
+            if size is not None and size != new_size:
+                raise ValueError(f"Attribute {key} has size {new_size}, expected {size}")
+            
+            size = new_size
+
+            setattr(self, key, kwargs[key])
+        
+        if size is None:
+            raise ValueError(f"Size of the batch cannot be None")
+        
+        self._length = size
+
+    @classmethod
+    def collate(cls: Type[T], batch_list: list[T]) -> T:
+        collated_attrs = {}
+        type_hints = get_type_hints(cls)
+        
+        l = len(batch_list)
+        
+        if l == 0:
+            raise ValueError(f"Cannot collate an empty list of {cls.__name__}")
+        
+        for key in type_hints.keys():
+            attr_list = [getattr(obj, key) for obj in batch_list]
+
+            if isinstance(attr_list[0], Tensor):
+                collated_attrs[key] = cat(tensors=tuple(attr_list), dim=0)
+            elif isinstance(attr_list[0], list):
+                collated_attrs[key] = [item for sublist in attr_list for item in sublist]
+            else:
+                raise ValueError(f"Unsupported attribute type for collation: {type(attr_list[0])}")
+            
+        collated_instance = cls(**collated_attrs)
+        return collated_instance
+    
+    def to(self: T, device: Device | None = None, dtype: DType | None = None) -> T:
+        for key in get_type_hints(self.__class__):
+            value = getattr(self, key)
+            if isinstance(value, Tensor):
+                setattr(self, key, value.to(device, dtype))
+            elif isinstance(value, list):
+                setattr(self, key, value)
+            else:
+                raise ValueError(f"Unsupported attribute type for to: {type(value)}")
+        return self
+    
+    def __len__(self) -> int:
+        return self._length
+    
+    def to_dict(self):
+        return {attr: getattr(self, attr) for attr in get_type_hints(self.__class__)}
+    
+    def split(self: T) -> list[T]:
+        result : list[T] = []
+        l = len(self)
+        for i in range(l):
+            args = {key: getattr(self, key)[i:i+1] for key in get_type_hints(self.__class__)}
+            result.append(self.__class__(**args))
+        return result
+
+    def __iter__(self):
+        for batch in self.split():
+            yield batch
+    
+    @classmethod
+    def load(cls: Type[T], filename: Path) -> T:
+        return cls(**torch_load(filename, map_location='cpu'))
+    
+    def save(self, filename: Path) -> None:
+        torch_save(self.to_dict(), filename)
+
+    def clone(self: T) -> T:
+        return self.__class__(**self.to_dict())

--- a/src/refiners/training_utils/batch.py
+++ b/src/refiners/training_utils/batch.py
@@ -6,6 +6,7 @@ from torch import Tensor, cat, device as Device, dtype as DType, load as torch_l
 from refiners.fluxion.utils import summarize_tensor  # type: ignore
 
 T = TypeVar("T", bound="BaseBatch")
+AttrType = Tensor | list[Any]
 
 
 def simple_hint(hint: Type[Any]) -> Type[Any]:
@@ -23,65 +24,59 @@ class TypeCheckMeta(type):
         if new_class.__name__ == "BaseBatch":
             return new_class
 
-        batch_attr_types = new_class.batch_attr_types()
-        if len(batch_attr_types) == 0:
-            raise ValueError(f"At least one attribute with type hint is required for {new_class.__name__}")
+        attr_types = new_class.attr_types()
+        if len(attr_types) == 0:
+            raise ValueError(f"At least one attribute is required for '{new_class.__name__}'")
 
-        for attr_key, attr_hint in batch_attr_types.items():
-            if not simple_hint(attr_hint) in [Tensor, list]:
-                raise TypeError(f"Type of '{attr_key}' must be Tensor or list, got {attr_hint}")
+        for attr_name, attr_type in attr_types.items():
+            if not attr_type in [Tensor, list]:
+                raise TypeError(f"Type of '{attr_name}' must be 'Tensor' or 'list', got '{attr_type.__name__}'")
 
         return new_class
 
 
-BatchAttrType = Tensor | list[Any]
-
-
 class BaseBatch(metaclass=TypeCheckMeta):
     @classmethod
-    def batch_attr_types(cls: Type[T]) -> dict[str, Type[BatchAttrType]]:
+    def attr_types(cls: Type[T]) -> dict[str, Type[AttrType]]:
         type_hints = get_type_hints(cls)
-        return {name: simple_hint(hint) for name, hint in type_hints.items() if name != "_length"}
+        return {name: simple_hint(hint) for name, hint in type_hints.items()}
 
-    def __init__(self, **kwargs: BatchAttrType):
-        batch_attr_types = self.__class__.batch_attr_types()
+    def __init__(self, **kwargs: AttrType):
+        attr_types = self.__class__.attr_types()
 
         size = None
 
-        for arg_key in kwargs:
-            if arg_key not in batch_attr_types:
-                raise ValueError(f"Attribute '{arg_key}' is not valid")
+        for attr_name in kwargs:
+            if attr_name not in attr_types:
+                raise ValueError(f"Attribute '{attr_name}' is not valid")
 
-        for type_key in batch_attr_types:
-            if type_key not in kwargs:
-                raise ValueError(f"Missing required attribute '{type_key}'")
+        for attr_name in attr_types:
+            if attr_name not in kwargs:
+                raise ValueError(f"Missing required attribute '{attr_name}'")
 
-        for arg_key in kwargs:
-            self.__setattr__(arg_key, kwargs[arg_key], check_size=False)
-            new_size = self.attr_length(arg_key)
+        for attr_name in kwargs:
+            self.__setattr__(attr_name, kwargs[attr_name], check_size=False)
+            new_size = self.attr_length(attr_name)
             if size is not None and size != new_size:
-                raise ValueError(f"Attribute '{arg_key}' has size {new_size}, expected {size}")
+                raise ValueError(f"Attribute '{attr_name}' has size {new_size}, expected {size}")
             size = new_size
 
             if size == 0:
-                raise ValueError(f"Attribute '{arg_key}' is empty, empty attributes are not permitted")
+                raise ValueError(f"Attribute '{attr_name}' is empty, empty attributes are not permitted")
 
-        if size is None:
-            raise ValueError(f"Empty batch is not valid")
-
-    def __getattr__(self, name: str) -> BatchAttrType:
-        if name in self.__class__.batch_attr_types():
+    def __getattr__(self, name: str) -> AttrType:
+        if name in self.__class__.attr_types():
             return getattr(self, name)
         else:
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def __setattr__(self, name: str, value: Any, check_size: bool = True) -> None:
-        batch_attr_types = self.__class__.batch_attr_types()
-        if name in batch_attr_types:
-            simple_type_hint = batch_attr_types[name]
-            if not isinstance(value, simple_type_hint):
+        attr_types = self.__class__.attr_types()
+        if name in attr_types:
+            attr_type = attr_types[name]
+            if not isinstance(value, attr_type):
                 raise TypeError(
-                    f"Invalid type for attribute '{name}': Expected {simple_type_hint.__name__}, got {type(value).__name__}"
+                    f"Invalid type for attribute '{name}': Expected '{attr_type.__name__}', got '{type(value).__name__}'"
                 )
             if isinstance(value, list):
                 new_size = len(value)
@@ -98,19 +93,19 @@ class BaseBatch(metaclass=TypeCheckMeta):
     @classmethod
     def collate(cls: Type[T], batch_list: list[T]) -> T:
         collated_attrs: dict[str, Any] = {}
-        batch_attr_types = cls.batch_attr_types()
+        attr_types = cls.attr_types()
 
         if len(batch_list) == 0:
             raise ValueError(f"Cannot collate an empty list of {cls.__name__}")
 
-        for type_key, simple_type_hint in batch_attr_types.items():
-            attr_list: list[BatchAttrType] = [getattr(obj, type_key) for obj in batch_list]
+        for attr_name, attr_type in attr_types.items():
+            attr_list = [getattr(obj, attr_name) for obj in batch_list]
 
-            if simple_type_hint == Tensor:
+            if attr_type == Tensor:
                 tensor_tuple = cast(tuple[Tensor, ...], tuple(attr_list))
-                collated_attrs[type_key] = cat(tensor_tuple, dim=0)
+                collated_attrs[attr_name] = cat(tensor_tuple, dim=0)
             else:
-                collated_attrs[type_key] = [item for sublist in attr_list for item in sublist]
+                collated_attrs[attr_name] = [item for sublist in attr_list for item in sublist]
 
         return cls(**collated_attrs)
 
@@ -119,24 +114,24 @@ class BaseBatch(metaclass=TypeCheckMeta):
             raise ValueError(f"Unsupported type for addition: {type(other)}")
 
         collated_attrs: dict[str, Any] = {}
-        batch_attr_types = self.__class__.batch_attr_types()
-        for type_key, simple_type_hint in batch_attr_types.items():
-            self_attr = getattr(self, type_key)
-            if simple_type_hint == Tensor:
-                collated_attrs[type_key] = cat(tensors=(self_attr, getattr(other, type_key)), dim=0)
+        attr_types = self.__class__.attr_types()
+        for attr_name, attr_type in attr_types.items():
+            self_attr = getattr(self, attr_name)
+            if attr_type == Tensor:
+                collated_attrs[attr_name] = cat(tensors=(self_attr, getattr(other, attr_name)), dim=0)
             else:
-                collated_attrs[type_key] = self_attr + getattr(other, type_key)
+                collated_attrs[attr_name] = self_attr + getattr(other, attr_name)
 
         return self.__class__(**collated_attrs)
 
     def to(self: T, device: Device | None = None, dtype: DType | None = None) -> T:
-        batch_attr_types = self.__class__.batch_attr_types()
-        for type_key, simple_type_hint in batch_attr_types.items():
-            value = getattr(self, type_key)
-            if simple_type_hint == Tensor:
-                setattr(self, type_key, value.to(device, dtype))
+        attr_types = self.__class__.attr_types()
+        for attr_name, attr_type in attr_types.items():
+            value = getattr(self, attr_name)
+            if attr_type == Tensor:
+                setattr(self, attr_name, value.to(device, dtype))
             else:
-                setattr(self, type_key, value)
+                setattr(self, attr_name, value)
 
         return self
 
@@ -148,16 +143,16 @@ class BaseBatch(metaclass=TypeCheckMeta):
             return value.shape[0]
 
     def __len__(self) -> int:
-        return self.attr_length(list(self.__class__.batch_attr_types().keys())[0])
+        return self.attr_length(list(self.__class__.attr_types().keys())[0])
 
-    def to_dict(self) -> dict[str, BatchAttrType]:
-        return {type_key: getattr(self, type_key) for type_key in self.__class__.batch_attr_types()}
+    def to_dict(self) -> dict[str, AttrType]:
+        return {attr_name: getattr(self, attr_name) for attr_name in self.__class__.attr_types()}
 
     def split(self: T) -> list[T]:
         result: list[T] = []
         l = len(self)
         for i in range(l):
-            args = {type_key: getattr(self, type_key)[i : i + 1] for type_key in self.__class__.batch_attr_types()}
+            args = {attr_name: getattr(self, attr_name)[i : i + 1] for attr_name in self.__class__.attr_types()}
             result.append(self.__class__(**args))
         return result
 
@@ -181,14 +176,14 @@ class BaseBatch(metaclass=TypeCheckMeta):
         dict = self.to_dict()
         other_dict = __value.to_dict()
 
-        for key in dict:
-            if isinstance(dict[key], Tensor):
-                condition = dict[key] == other_dict[key]
+        for attr_name in dict:
+            if isinstance(dict[attr_name], Tensor):
+                condition = dict[attr_name] == other_dict[attr_name]
                 casted = cast(Tensor, condition)
                 if not casted.all():
                     return False
             else:
-                if dict[key] != other_dict[key]:
+                if dict[attr_name] != other_dict[attr_name]:
                     return False
         return True
 
@@ -197,18 +192,18 @@ class BaseBatch(metaclass=TypeCheckMeta):
 
     def __repr__(self) -> str:
         attr_strs: list[str] = []
-        for type_key in self.__class__.batch_attr_types():
-            attr_value = getattr(self, type_key)
+        for attr_name in self.__class__.attr_types():
+            attr_value = getattr(self, attr_name)
             if isinstance(attr_value, list):
-                attr_strs.append(f"{type_key}={attr_value}")
+                attr_strs.append(f"{attr_name}={attr_value}")
             else:
-                attr_strs.append(f"{type_key}={summarize_tensor(attr_value)}")
+                attr_strs.append(f"{attr_name}={summarize_tensor(attr_value)}")
         return f"{self.__class__.__name__}(size={len(self)})[{','.join(attr_strs)}]"
 
     def __getitem__(self: T, key: slice | int | list[int] | list[bool]) -> T:
         if isinstance(key, slice):
             return self.__class__(
-                **{type_key: getattr(self, type_key)[key] for type_key in self.__class__.batch_attr_types()}
+                **{attr_name: getattr(self, attr_name)[key] for attr_name in self.__class__.attr_types()}
             )
         elif isinstance(key, int):
             return self[key : key + 1]

--- a/src/refiners/training_utils/trainer.py
+++ b/src/refiners/training_utils/trainer.py
@@ -25,6 +25,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from refiners.fluxion import layers as fl
 from refiners.fluxion.utils import no_grad
+from refiners.training_utils.batch import BaseBatch
 from refiners.training_utils.callback import (
     Callback,
     CallbackConfig,
@@ -38,7 +39,6 @@ from refiners.training_utils.common import (
 )
 from refiners.training_utils.config import BaseConfig, LRSchedulerType, ModelConfig
 from refiners.training_utils.gradient_clipping import GradientClipping, GradientClippingConfig
-from refiners.training_utils.batch import BaseBatch
 
 
 class WarmupScheduler(LRScheduler):
@@ -60,6 +60,7 @@ class WarmupScheduler(LRScheduler):
         else:
             self.scheduler.step(epoch=epoch)
             self._step_count += 1
+
 
 BatchType = TypeVar("BatchType", bound=BaseBatch)
 ConfigType = TypeVar("ConfigType", bound=BaseConfig)

--- a/tests/training_utils/test_batch.py
+++ b/tests/training_utils/test_batch.py
@@ -12,7 +12,7 @@ def test_inherit_no_attribute() -> None:
         class NoAttrBatch(BaseBatch):  # type: ignore
             pass
 
-    assert "At least one attribute with type hint is required for NoAttrBatch" == str(excinfo.value)
+    assert "At least one attribute is required for 'NoAttrBatch'" == str(excinfo.value)
 
 
 def test_inherit_non_list_errors() -> None:
@@ -21,7 +21,7 @@ def test_inherit_non_list_errors() -> None:
         class StrBatch(BaseBatch):  # type: ignore
             foo: str
 
-    assert "Type of 'foo' must be Tensor or list, got <class 'str'>" == str(excinfo.value)
+    assert "Type of 'foo' must be 'Tensor' or 'list', got 'str'" == str(excinfo.value)
 
 
 class MockBatch(BaseBatch):
@@ -50,7 +50,7 @@ def test_attr_type_error() -> None:
     with pytest.raises(TypeError) as excinfo:
         MockBatch(foo="foo", bar=randn(5, 5), indices=[0, 1, 2, 3, 4])  # type: ignore
 
-    assert "Invalid type for attribute 'foo': Expected Tensor, got str" == str(excinfo.value)
+    assert "Invalid type for attribute 'foo': Expected 'Tensor', got 'str'" == str(excinfo.value)
 
 
 def test_extra_missing_attr() -> None:

--- a/tests/training_utils/test_batch.py
+++ b/tests/training_utils/test_batch.py
@@ -1,80 +1,101 @@
-from json import load
-from torch import Tensor, randn, tensor; load as torch_load
-from refiners.training_utils.batch import BaseBatch
 from pathlib import Path
+
 import pytest
+from torch import Tensor, load as torch_load, randn, tensor  # type: ignore
+
+from refiners.training_utils.batch import BaseBatch
+
 
 def test_inherit_no_attribute() -> None:
     with pytest.raises(ValueError) as excinfo:
-        class NoAttrBatch(BaseBatch):
+
+        class NoAttrBatch(BaseBatch):  # type: ignore
             pass
-    assert "attribute 'foo' is not compatible with Batch, type hint should be list or Tensor" in str(excinfo.value)
+
+    assert "At least one attribute with type hint is required for NoAttrBatch" == str(excinfo.value)
 
 
 def test_inherit_non_list_errors() -> None:
-    with pytest.raises(ValueError) as excinfo:
-        class StrBatch(BaseBatch):
-            foo: str
-    assert "attribute 'foo' is not compatible with Batch, type hint should be list or Tensor" in str(excinfo.value)
+    with pytest.raises(TypeError) as excinfo:
 
-class TestBatch(BaseBatch):
+        class StrBatch(BaseBatch):  # type: ignore
+            foo: str
+
+    assert "Type of 'foo' must be Tensor or list, got <class 'str'>" == str(excinfo.value)
+
+
+class MockBatch(BaseBatch):
     foo: Tensor
     bar: Tensor
     indices: list[int]
 
+
 def test_single_batch() -> None:
-    single = TestBatch(foo=randn(1, 10), bar=randn(1, 5), indices=[0])
+    single = MockBatch(foo=randn(1, 10), bar=randn(1, 5), indices=[0])
     assert len(single) == 1
 
+
 def test_l5_batch() -> None:
-    l5 = TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2, 3, 4])
+    l5 = MockBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2, 3, 4])
     assert len(l5) == 5
     total = 0
     for single in l5:
         assert len(single) == 1
         total += 1
-    
+
     assert total == 5
+
+
+def test_attr_type_error() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        MockBatch(foo="foo", bar=randn(6, 5))  # type: ignore
+
+    assert "Invalid type for attribute 'foo': Expected Tensor, got str" == str(excinfo.value)
+
 
 def test_extra_missing_attr() -> None:
     with pytest.raises(ValueError) as excinfo:
-        TestBatch(foo=randn(5, 10), bar=randn(6, 5))
-    
-    assert "Attribute 'indices' is missing" in str(excinfo.value)
-    
+        MockBatch(foo=randn(5, 10), bar=randn(5, 5))
+
+    assert "Missing required attribute 'indices'" == str(excinfo.value)
+
     with pytest.raises(ValueError) as excinfo:
-        TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2], extra=["a", "b", "c"])
-    
-    assert "Attribute 'extra' is not valid" in str(excinfo.value)
-    
+        MockBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2], extra=["a", "b", "c"])
+
+    assert "Attribute 'extra' is not valid" == str(excinfo.value)
+
+
 def test_inhomogeneous_sizes_raise_errors() -> None:
     with pytest.raises(ValueError) as excinfo:
-        TestBatch(foo=randn(5, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
-    
-    assert "Attribute 'bar' has size 6, expected 5" in str(excinfo.value)
-    
+        MockBatch(foo=randn(5, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
+
+    assert "Attribute 'bar' has size 6, expected 5" == str(excinfo.value)
+
     with pytest.raises(ValueError) as excinfo:
-        TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2])
-    
-    assert "Attribute 'indices' has size 3, expected 5" in str(excinfo.value)
-    
+        MockBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2])
+
+    assert "Attribute 'indices' has size 3, expected 5" == str(excinfo.value)
+
+
 def test_empty_attr_raise_errors() -> None:
     with pytest.raises(ValueError) as excinfo:
-        TestBatch(foo=randn(0, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
-    
-    assert "Attribute 'foo' is empty, empty attributes are not permitted" in str(excinfo.value)
+        MockBatch(foo=randn(0, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
+
+    assert "Attribute 'foo' is empty, empty attributes are not permitted" == str(excinfo.value)
+
 
 def test_load_save_batch() -> None:
-    loaded = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    loaded = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
     tmp_filename = Path(".pytest_cache/test_batch_tmp.pt")
     loaded.save(tmp_filename)
-    second_loaded = TestBatch.load(tmp_filename)
+    second_loaded = MockBatch.load(tmp_filename)
     assert second_loaded == loaded
 
+
 def test_equality() -> None:
-    b1 = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    b1 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
     b2 = b1.clone()
     assert b2 == b1
     assert not b1 != b2
-    b3 = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    b3 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
     assert b3 != b1

--- a/tests/training_utils/test_batch.py
+++ b/tests/training_utils/test_batch.py
@@ -1,0 +1,80 @@
+from json import load
+from torch import Tensor, randn, tensor; load as torch_load
+from refiners.training_utils.batch import BaseBatch
+from pathlib import Path
+import pytest
+
+def test_inherit_no_attribute() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        class NoAttrBatch(BaseBatch):
+            pass
+    assert "attribute 'foo' is not compatible with Batch, type hint should be list or Tensor" in str(excinfo.value)
+
+
+def test_inherit_non_list_errors() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        class StrBatch(BaseBatch):
+            foo: str
+    assert "attribute 'foo' is not compatible with Batch, type hint should be list or Tensor" in str(excinfo.value)
+
+class TestBatch(BaseBatch):
+    foo: Tensor
+    bar: Tensor
+    indices: list[int]
+
+def test_single_batch() -> None:
+    single = TestBatch(foo=randn(1, 10), bar=randn(1, 5), indices=[0])
+    assert len(single) == 1
+
+def test_l5_batch() -> None:
+    l5 = TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2, 3, 4])
+    assert len(l5) == 5
+    total = 0
+    for single in l5:
+        assert len(single) == 1
+        total += 1
+    
+    assert total == 5
+
+def test_extra_missing_attr() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        TestBatch(foo=randn(5, 10), bar=randn(6, 5))
+    
+    assert "Attribute 'indices' is missing" in str(excinfo.value)
+    
+    with pytest.raises(ValueError) as excinfo:
+        TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2], extra=["a", "b", "c"])
+    
+    assert "Attribute 'extra' is not valid" in str(excinfo.value)
+    
+def test_inhomogeneous_sizes_raise_errors() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        TestBatch(foo=randn(5, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
+    
+    assert "Attribute 'bar' has size 6, expected 5" in str(excinfo.value)
+    
+    with pytest.raises(ValueError) as excinfo:
+        TestBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[0, 1, 2])
+    
+    assert "Attribute 'indices' has size 3, expected 5" in str(excinfo.value)
+    
+def test_empty_attr_raise_errors() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        TestBatch(foo=randn(0, 10), bar=randn(6, 5), indices=[0, 1, 2, 3, 4])
+    
+    assert "Attribute 'foo' is empty, empty attributes are not permitted" in str(excinfo.value)
+
+def test_load_save_batch() -> None:
+    loaded = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    tmp_filename = Path(".pytest_cache/test_batch_tmp.pt")
+    loaded.save(tmp_filename)
+    second_loaded = TestBatch.load(tmp_filename)
+    assert second_loaded == loaded
+
+def test_equality() -> None:
+    b1 = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    b2 = b1.clone()
+    assert b2 == b1
+    assert not b1 != b2
+    b3 = TestBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1,2,3])
+    assert b3 != b1

--- a/tests/training_utils/test_batch.py
+++ b/tests/training_utils/test_batch.py
@@ -99,3 +99,16 @@ def test_equality() -> None:
     assert not b1 != b2
     b3 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
     assert b3 != b1
+
+
+def test_slicing() -> None:
+    b1 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
+    b1_0 = b1[0]
+    assert len(b1_0) == 1
+    b1_21 = b1[1:3]
+    assert len(b1_21) == 2
+    assert MockBatch.collate([b1_0, b1_21]) == b1
+
+    b1_0_2 = b1[[0, 2]]
+    assert len(b1_0_2) == 2
+    assert MockBatch.collate([b1_0_2[0], b1[1], b1_0_2[1]]) == b1

--- a/tests/training_utils/test_batch.py
+++ b/tests/training_utils/test_batch.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,10 @@ class MockBatch(BaseBatch):
     foo: Tensor
     bar: Tensor
     indices: list[int]
+
+
+def test_inspect() -> None:
+    assert "(foo: torch.Tensor, bar: torch.Tensor, indices: list[int])" == str(inspect.signature(MockBatch))
 
 
 def test_single_batch() -> None:
@@ -99,6 +104,22 @@ def test_equality() -> None:
     assert not b1 != b2
     b3 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
     assert b3 != b1
+
+
+def test_collate() -> None:
+    b1 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
+    b2 = MockBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[4, 5, 6, 7, 8])
+    b3 = MockBatch(foo=randn(1, 10), bar=randn(1, 5), indices=[9])
+    collated = MockBatch.collate([b1, b2, b3])
+    assert len(collated) == 9
+
+
+def test_add() -> None:
+    b1 = MockBatch(foo=randn(3, 10), bar=randn(3, 5), indices=[1, 2, 3])
+    b2 = MockBatch(foo=randn(5, 10), bar=randn(5, 5), indices=[4, 5, 6, 7, 8])
+    collated = MockBatch.collate([b1, b2])
+    added = b1 + b2
+    assert added == collated
 
 
 def test_slicing() -> None:

--- a/tests/training_utils/test_trainer.py
+++ b/tests/training_utils/test_trainer.py
@@ -10,9 +10,9 @@ from torch.optim import SGD
 
 from refiners.fluxion import layers as fl
 from refiners.fluxion.utils import norm
+from refiners.training_utils.batch import BaseBatch
 from refiners.training_utils.common import TimeUnit, count_learnable_parameters, human_readable_number
 from refiners.training_utils.config import BaseConfig, ModelConfig
-from refiners.training_utils.batch import BaseBatch
 from refiners.training_utils.trainer import (
     Trainer,
     TrainingClock,

--- a/tests/training_utils/test_trainer.py
+++ b/tests/training_utils/test_trainer.py
@@ -12,6 +12,7 @@ from refiners.fluxion import layers as fl
 from refiners.fluxion.utils import norm
 from refiners.training_utils.common import TimeUnit, count_learnable_parameters, human_readable_number
 from refiners.training_utils.config import BaseConfig, ModelConfig
+from refiners.training_utils.batch import BaseBatch
 from refiners.training_utils.trainer import (
     Trainer,
     TrainingClock,
@@ -22,8 +23,7 @@ from refiners.training_utils.trainer import (
 )
 
 
-@dataclass
-class MockBatch:
+class MockBatch(BaseBatch):
     inputs: torch.Tensor
     targets: torch.Tensor
 

--- a/tests/training_utils/test_trainer.py
+++ b/tests/training_utils/test_trainer.py
@@ -1,5 +1,4 @@
 import warnings
-from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 


### PR DESCRIPTION
This is a proposal for a `Batch` class to be used when training.

## Context

When training, we always need to manipulate batched data, those data are generally Tensors (where batch_size is `shape[0]`) and lists (where batch_size is `len(lst)`)

Morever, it is quite classic to get mixed up between `list[Image.Image]` or `Tensor` that might represent the same thing (a group of images), so having the flexbility to switch the structure of the batches easily in one line while keeping the rest of the batching logic safe is quite convenient.

## Proposal

This `BaseBatch` class will both provide the ability to handle this, while providing type checks and size checks at different levels to raise the error as soon as possible in the process.

### API

```python
from refiners.training_utils.batch import BaseBatch
from torch import Tensor

class MockBatch(BaseBatch):
    foo: Tensor
    bar: Tensor
    indices: list[int]
```
### Features

* Checking that hint are list or tensor when inherinting
* Making sure all the args have the same (non-zero) size
* Even if you do not use pyright, first-level-typing is checked when you inherit from `BaseBatch`
* Training related features : `cls.collate`, `inst.to`, `cls.load`, `inst.save`
* Pythonic stuff like `__len__`, `__iter__`, `to_dict`, `clone`, `__eq__`, `__getitem__`, `__repr__`

### Questions

* Currently Batch cannot have 0-size, this can be discussed.
* The `batch.py` and `test_batch.py` could also have been put in `training.py` and `test_training.py`, please share your thoughts
* Not sure between `BaseBatch`, `AbstractBatch` or simply `Batch` as the top-level name

## Going further

There might be a second level PR for this, with jax-typed batch, but i feel it can be done incrementally, and it's easier to discuss this step by step.
