### PR TITLE
Change weight decay for Optimizer to normal PyTorch default

### DIFF
--- a/src/refiners/training_utils/config.py
+++ b/src/refiners/training_utils/config.py
@@ -90,7 +90,7 @@ class OptimizerConfig(BaseModel):
     learning_rate: float = 1e-4
     betas: tuple[float, float] = (0.9, 0.999)
     eps: float = 1e-8
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-2
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
Weight decay is default to 0 with the current config, we change it to 1e-2 to follow PyTorch convention

See: https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html#adamw