### PR TITLE
Make LoRA's weight initialization overridable

### DIFF
--- a/src/refiners/fluxion/adapters/lora.py
+++ b/src/refiners/fluxion/adapters/lora.py
@@ -14,10 +14,9 @@ T = TypeVar("T", bound=fl.WeightedModule)
 class Lora(Generic[T], fl.Chain, ABC):
     """Low-Rank Adaptation (LoRA) layer.
 
-    This layer is composed of two [`WeightedModule`][refiners.fluxion.layers.WeightedModule]:
-
-    - `down`: initialized with a random normal distribution
-    - `up`: initialized with zeros
+    This layer's purpose is to approximate a given layer by two smaller layers:
+    the [`down`][refiners.fluxion.adapters.lora.Lora.down] layer (aka A) and the [`up`][refiners.fluxion.adapters.lora.Lora.up] layer (aka B).
+    See [[ arXiv:2106.09685] LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685) for more details.
 
     Note:
         This layer is not meant to be used directly.
@@ -53,7 +52,10 @@ class Lora(Generic[T], fl.Chain, ABC):
             *self.lora_layers(device=device, dtype=dtype),
             fl.Multiply(scale),
         )
+        self.reset_parameters()
 
+    def reset_parameters(self) -> None:
+        """Reset the parameters of up and down layers."""
         normal_(tensor=self.down.weight, std=1 / self.rank)
         zeros_(tensor=self.up.weight)
 


### PR DESCRIPTION
As per Section 4.1 of the paper (https://arxiv.org/abs/2106.09685), we initialize the weights of the LoRA like so:
- up -> zeros
- down -> normal (gaussian)

Though in pratice, many other implementation do the following:
- up -> zeros
- down -> kaiming_uniform

see Microsoft's code: https://github.com/microsoft/LoRA/blob/4c0333854cb905966f8cc4e9a74068c1e507c7b7/loralib/layers.py#L122-L125

Let's make the code slightly more generic by allowing the initialization to be overridable.