### PR TITLE
SAM e2e test tolerance explained

### DIFF
--- a/tests/foundationals/segment_anything/utils.py
+++ b/tests/foundationals/segment_anything/utils.py
@@ -40,6 +40,7 @@ class FacebookSAM(nn.Module):
 
 class FacebookSAMPredictor:
     model: FacebookSAM
+    features: Tensor
 
     def set_image(self, image: NDArrayUInt8, image_format: str = "RGB") -> None: ...
 


### PR DESCRIPTION
This is a follow up of #327 

Most of differences between between facebook SAM and refiners SAM comes from 2 sources : 
* the image_embedding
* numpy is not a deps in refiners, and points rescaling is made with torch

A unit test is added to show that we can do `torch.equal` test on SAM by avoiding those 2 limitations