### PR TITLE
HQ-SAM logit torch.equal test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ exclude_also = [
 
 [tool.typos.default]
 extend-words = { adaptee = "adaptee" }
-extend-ignore-identifiers-re = ["NDArray*"]
+extend-ignore-identifiers-re = ["NDArray*", "interm"]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/tests/foundationals/segment_anything/utils.py
+++ b/tests/foundationals/segment_anything/utils.py
@@ -57,6 +57,8 @@ class FacebookSAMPredictor:
 
 class FacebookSAMPredictorHQ:
     model: FacebookSAM
+    features: Tensor
+    interm_features: Tensor
 
     def set_image(self, image: NDArrayUInt8, image_format: str = "RGB") -> None: ...
 


### PR DESCRIPTION
Following #331, this PR creates a `torch.equal` test in HQ-SAM by bypassing refiners ViT embedding.