### PR TITLE
 Fix IPAdapter injection

### DIFF
--- a/tests/adapters/test_ip_adapter.py
+++ b/tests/adapters/test_ip_adapter.py
@@ -35,6 +35,10 @@ def test_inject_eject(k_unet: type[SD1UNet] | type[SDXLUNet], test_device: torch
     assert repr(unet) != initial_repr
     adapter.eject()
     assert repr(unet) == initial_repr
+    adapter.inject()
+    assert repr(unet) != initial_repr
+    adapter.eject()
+    assert repr(unet) == initial_repr
 
 
 @no_grad()


### PR DESCRIPTION
Currently, because the IPAdapter makes a [structural_copy](https://github.com/finegrain-ai/refiners/blob/5c937b184a971f76d46a16b95b1b31c4be492729/src/refiners/foundationals/latent_diffusion/image_prompt.py#L287) of the target (fl.Attention), this means that modification done to the target between the IPAdapter instanciantion and it's in injection are lost (e.g. when making LoRAs).

Also, currently if an ImageCrossAttention layer has multiple Multiply (e.g. because it has been LoRA-ified), using the scale setter and getter may not set/get the scale of [the main ](https://github.com/finegrain-ai/refiners/blob/5c937b184a971f76d46a16b95b1b31c4be492729/src/refiners/foundationals/latent_diffusion/image_prompt.py#L266)[Multiply](https://github.com/finegrain-ai/refiners-internal/blob/5c937b184a971f76d46a16b95b1b31c4be492729/src/refiners/foundationals/latent_diffusion/image_prompt.py#L266).

All tests are green.