### PR TITLE
test weights: fix control-lora expected hashes

### DIFF
--- a/scripts/prepare_test_weights.py
+++ b/scripts/prepare_test_weights.py
@@ -303,13 +303,13 @@ def download_control_lora_fooocus():
     download_file(
         url=f"https://huggingface.co/lllyasviel/misc/resolve/main/control-lora-canny-rank128.safetensors",
         dest_folder=base_folder,
-        expected_hash="4d505134",
+        expected_hash="fec9e32b",
     )
 
     download_file(
         url=f"https://huggingface.co/lllyasviel/misc/resolve/main/fooocus_xl_cpds_128.safetensors",
         dest_folder=base_folder,
-        expected_hash="d81aa461",
+        expected_hash="fc04b120",
     )
 
 

--- a/scripts/prepare_test_weights.py
+++ b/scripts/prepare_test_weights.py
@@ -96,8 +96,10 @@ def download_file(
             print(f"❌{skip_icon} {response.status_code} ERROR {readable_size:<8} {url}")
         return
 
-    if skip_existing and os.path.exists(dest_filename):
+    if skip_existing and is_downloaded:
         print(f"{skip_icon}️ Skipping previously downloaded {url}")
+        if expected_hash is not None:
+            check_hash(dest_filename, expected_hash)
         return
 
     os.makedirs(dest_folder, exist_ok=True)


### PR DESCRIPTION
These were plain wrong. In addition, do verify hashes of already downloaded files (and exit early if not valid).