### PR TITLE
 (DINOv2) Implement positional encoding interpolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv/
 
 # tests' model weights
 tests/weights/
+tests/repos/
 
 # ruff
 .ruff_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,12 @@ Then, download and convert all the necessary weights. Be aware that this will us
 python scripts/prepare_test_weights.py
 ```
 
+Some tests require cloning the original implementation of the model as they use `torch.hub.load`:
+
+```bash
+git clone git@github.com:facebookresearch/dinov2.git tests/repos/dinov2
+```
+
 Finally, run the tests:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ exclude_also = [
 
 [tool.typos.default]
 extend-words = { adaptee = "adaptee" }
-extend-ignore-identifiers-re = ["NDArray*", "interm"]
+extend-ignore-identifiers-re = ["NDArray*", "interm", "af000ded"]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/scripts/conversion/convert_dinov2.py
+++ b/scripts/conversion/convert_dinov2.py
@@ -20,7 +20,7 @@ def convert_dinov2_facebook(weights: dict[str, torch.Tensor]) -> None:
 
     rename_keys: list[tuple[str, str]] = [
         ("cls_token", "Concatenate.ClassToken.Parameter.weight"),
-        ("pos_embed", "PositionalEncoder.Parameter.weight"),
+        ("pos_embed", "PositionalEncoder.PositionalEmbedding.Parameter.weight"),
         ("patch_embed.proj.weight", "Concatenate.PatchEncoder.Conv2d.weight"),
         ("patch_embed.proj.bias", "Concatenate.PatchEncoder.Conv2d.bias"),
         ("norm.weight", "LayerNorm.weight"),

--- a/scripts/prepare_test_weights.py
+++ b/scripts/prepare_test_weights.py
@@ -388,16 +388,6 @@ def download_dinov2():
     ]
     download_files(urls, weights_folder)
 
-    # For testing (note: versions with registers are not available yet on HuggingFace)
-    for repo in ["dinov2-small", "dinov2-base", "dinov2-large"]:
-        base_folder = os.path.join(test_weights_dir, "facebook", repo)
-        urls = [
-            f"https://huggingface.co/facebook/{repo}/raw/main/config.json",
-            f"https://huggingface.co/facebook/{repo}/raw/main/preprocessor_config.json",
-            f"https://huggingface.co/facebook/{repo}/resolve/main/pytorch_model.bin",
-        ]
-        download_files(urls, base_folder)
-
 
 def download_lcm_base():
     base_folder = os.path.join(test_weights_dir, "latent-consistency/lcm-sdxl")

--- a/scripts/prepare_test_weights.py
+++ b/scripts/prepare_test_weights.py
@@ -688,37 +688,37 @@ def convert_dinov2():
         "convert_dinov2.py",
         "tests/weights/dinov2_vits14_pretrain.pth",
         "tests/weights/dinov2_vits14_pretrain.safetensors",
-        expected_hash="b7f9b294",
+        expected_hash="af000ded",
     )
     run_conversion_script(
         "convert_dinov2.py",
         "tests/weights/dinov2_vitb14_pretrain.pth",
         "tests/weights/dinov2_vitb14_pretrain.safetensors",
-        expected_hash="d72c767b",
+        expected_hash="d6294087",
     )
     run_conversion_script(
         "convert_dinov2.py",
         "tests/weights/dinov2_vitl14_pretrain.pth",
         "tests/weights/dinov2_vitl14_pretrain.safetensors",
-        expected_hash="71eb98d1",
+        expected_hash="ddd4819f",
     )
     run_conversion_script(
         "convert_dinov2.py",
         "tests/weights/dinov2_vits14_reg4_pretrain.pth",
         "tests/weights/dinov2_vits14_reg4_pretrain.safetensors",
-        expected_hash="89118b46",
+        expected_hash="080247c7",
     )
     run_conversion_script(
         "convert_dinov2.py",
         "tests/weights/dinov2_vitb14_reg4_pretrain.pth",
         "tests/weights/dinov2_vitb14_reg4_pretrain.safetensors",
-        expected_hash="b0296f77",
+        expected_hash="5cd4d408",
     )
     run_conversion_script(
         "convert_dinov2.py",
         "tests/weights/dinov2_vitl14_reg4_pretrain.pth",
         "tests/weights/dinov2_vitl14_reg4_pretrain.safetensors",
-        expected_hash="b3d877dc",
+        expected_hash="b1221702",
     )
 
 

--- a/src/refiners/fluxion/layers/sampling.py
+++ b/src/refiners/fluxion/layers/sampling.py
@@ -16,15 +16,26 @@ class Interpolate(Module):
     This layer wraps [`torch.nn.functional.interpolate`][torch.nn.functional.interpolate].
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        mode: str = "nearest",
+        antialias: bool = False,
+    ) -> None:
         super().__init__()
+        self.mode = mode
+        self.antialias = antialias
 
     def forward(
         self,
         x: Tensor,
         shape: Size,
     ) -> Tensor:
-        return interpolate(x, shape)
+        return interpolate(
+            x=x,
+            size=shape,
+            mode=self.mode,
+            antialias=self.antialias,
+        )
 
 
 class Downsample(Chain):

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -40,12 +40,18 @@ def pad(x: Tensor, pad: Iterable[int], value: float = 0.0, mode: str = "constant
     return _pad(input=x, pad=pad, value=value, mode=mode)  # type: ignore
 
 
-def interpolate(x: Tensor, factor: float | torch.Size, mode: str = "nearest") -> Tensor:
-    return (
-        _interpolate(x, scale_factor=factor, mode=mode)
-        if isinstance(factor, float | int)
-        else _interpolate(x, size=factor, mode=mode)
-    )  # type: ignore
+def interpolate(
+    x: Tensor,
+    size: torch.Size,
+    mode: str = "nearest",
+    antialias: bool = False,
+) -> Tensor:
+    return _interpolate(  # type: ignore
+        input=x,
+        size=size,
+        mode=mode,
+        antialias=antialias,
+    )
 
 
 # Adapted from https://github.com/pytorch/vision/blob/main/torchvision/transforms/_functional_tensor.py

--- a/src/refiners/foundationals/dinov2/dinov2.py
+++ b/src/refiners/foundationals/dinov2/dinov2.py
@@ -146,6 +146,7 @@ class DINOv2_small_reg(ViT):
         num_layers (int): 12
         num_heads (int): 6
         num_registers (int): 4
+        interpolate_antialias (bool): True
     """
 
     def __init__(
@@ -166,6 +167,7 @@ class DINOv2_small_reg(ViT):
             num_layers=12,
             num_heads=6,
             num_registers=4,
+            interpolate_antialias=True,
             device=device,
             dtype=dtype,
         )
@@ -185,6 +187,7 @@ class DINOv2_base_reg(ViT):
         num_layers (int): 12
         num_heads (int): 12
         num_registers (int): 4
+        interpolate_antialias (bool): True
     """
 
     def __init__(
@@ -205,6 +208,7 @@ class DINOv2_base_reg(ViT):
             num_layers=12,
             num_heads=12,
             num_registers=4,
+            interpolate_antialias=True,
             device=device,
             dtype=dtype,
         )
@@ -224,6 +228,7 @@ class DINOv2_large_reg(ViT):
         num_layers (int): 24
         num_heads (int): 16
         num_registers (int): 4
+        interpolate_antialias (bool): True
     """
 
     def __init__(
@@ -244,6 +249,7 @@ class DINOv2_large_reg(ViT):
             num_layers=24,
             num_heads=16,
             num_registers=4,
+            interpolate_antialias=True,
             device=device,
             dtype=dtype,
         )
@@ -263,6 +269,7 @@ class DINOv2_large_reg(ViT):
 #             num_layers=40,
 #             num_heads=24,
 #             num_registers=4,
+#             interpolate_antialias=True,
 #             device=device,
 #             dtype=dtype,
 #         )

--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/model.py
@@ -228,7 +228,7 @@ class StableDiffusion_1_Inpainting(StableDiffusion_1):
 
         mask_tensor = torch.tensor(data=np.array(object=mask).astype(dtype=np.float32) / 255.0).to(device=self.device)
         mask_tensor = (mask_tensor > 0.5).unsqueeze(dim=0).unsqueeze(dim=0).to(dtype=self.dtype)
-        self.mask_latents = interpolate(x=mask_tensor, factor=torch.Size(latents_size))
+        self.mask_latents = interpolate(x=mask_tensor, size=torch.Size(latents_size))
 
         init_image_tensor = image_to_tensor(image=target_image, device=self.device, dtype=self.dtype) * 2 - 1
         masked_init_image = init_image_tensor * (1 - mask_tensor)

--- a/src/refiners/foundationals/segment_anything/model.py
+++ b/src/refiners/foundationals/segment_anything/model.py
@@ -232,9 +232,9 @@ class SegmentAnything(fl.Chain):
         Returns:
             The postprocessed masks.
         """
-        masks = interpolate(masks, factor=torch.Size((self.image_size, self.image_size)), mode="bilinear")
+        masks = interpolate(masks, size=torch.Size((self.image_size, self.image_size)), mode="bilinear")
         masks = masks[..., : target_size[0], : target_size[1]]  # remove padding added at `preprocess_image` time
-        masks = interpolate(masks, factor=torch.Size(original_size), mode="bilinear")
+        masks = interpolate(masks, size=torch.Size(original_size), mode="bilinear")
         return masks
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,12 @@ def test_weights_path() -> Path:
 
 
 @fixture(scope="session")
+def test_repos_path() -> Path:
+    from_env = os.getenv("REFINERS_TEST_REPOS_DIR")
+    return Path(from_env) if from_env else PARENT_PATH / "repos"
+
+
+@fixture(scope="session")
 def test_e2e_path() -> Path:
     return PARENT_PATH / "e2e"
 


### PR DESCRIPTION
This PR allows DINOv2 models to compute embeddings on tensors whose "resolution" is different from the default 518x518px resolution.

This implementation doesn't use the `scale_factor` argument of [`torch.nn.interpolate`](https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html), as per facebookresearch/dinov2#378.