### PR TITLE
Fix typos ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,11 @@ exclude_also = [
 ]
 
 [tool.typos.default]
-extend-words = { adaptee = "adaptee" }
 extend-ignore-identifiers-re = ["NDArray*", "interm", "af000ded"]
+
+[tool.typos.default.extend-words]
+adaptee = "adaptee"  # Common name for an adapter's target
+arange = "arange"  # Commonly used via `from torch import arange`
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
[`typos`](https://github.com/crate-ci/typos/) github action was updated to v1.20.1.
It now contains the rule [`arange->arrange`](https://github.com/crate-ci/typos/issues/955) which conflicts with every `torch.arange` call.

I also added a `.ignore` file which tells `typos` which files/directories to ignore, most notably we want to ignore `test/repos`, as third party repos may contains lots of typos.