### PR TITLE
Fix clock step inconsistencies on batch end

### DIFF
--- a/src/refiners/training_utils/clock.py
+++ b/src/refiners/training_utils/clock.py
@@ -179,10 +179,8 @@ class TrainingClock(Callback["Trainer[BaseConfig, Any]"]):
             self.log(f"Iteration {trainer.clock.iteration} started.")
         self.log(f"Step {trainer.clock.step} started.")
 
-    def on_batch_end(self, trainer: "Trainer[BaseConfig, Any]") -> None:
-        self.log(f"Step {trainer.clock.step} ended.")
-
     def on_backward_end(self, trainer: "Trainer[BaseConfig, Any]") -> None:
+        self.log(f"Step {trainer.clock.step} ended.")
         trainer.clock.step += 1
         trainer.clock.num_batches_processed += 1
         trainer.clock.num_minibatches_processed += 1

--- a/src/refiners/training_utils/common.py
+++ b/src/refiners/training_utils/common.py
@@ -66,7 +66,7 @@ def scoped_seed(seed: int | Callable[..., int] | None = None) -> Callable[..., C
             actual_seed = seed(*args) if callable(seed) else seed
             seed_everything(seed=actual_seed)
             result = func(*args, **kwargs)
-            logger.debug(f"Restoring previous seed state")
+            logger.trace(f"Restoring previous seed state")
             random.setstate(random_state)
             np.random.set_state(numpy_state)
             torch.set_rng_state(torch_state)


### PR DESCRIPTION
Previously, the logger for step end was called **after** incrementing the step, resulting in inconsistencies in the log messages:
<img width="688" alt="Capture d’écran 2024-03-28 à 16 58 30" src="https://github.com/finegrain-ai/refiners/assets/39882556/31694ecc-bb30-4a6d-ade9-e41c9f56bab6">

This PR fixes this issue:
<img width="683" alt="Capture d’écran 2024-04-05 à 15 49 50" src="https://github.com/finegrain-ai/refiners/assets/39882556/86ba4ffc-92d2-4e5b-9cdf-14122a9bb62d">
