### PR TITLE
Add init file to SAM tests

### DIFF
--- a/tests/foundationals/segment_anything/test_sam.py
+++ b/tests/foundationals/segment_anything/test_sam.py
@@ -258,8 +258,6 @@ def test_mask_decoder(facebook_sam_h: FacebookSAM, sam_h: SegmentAnythingH) -> N
 
     from segment_anything.modeling.common import LayerNorm2d  # type: ignore
 
-    import refiners.fluxion.layers as fl
-
     assert issubclass(LayerNorm2d, nn.Module)
     custom_layers = {LayerNorm2d: fl.LayerNorm2d}
 


### PR DESCRIPTION
Fixes an `import file mismatch` error when running `pytest`.