### PR TITLE
Add event configs to Callback

### DIFF
--- a/src/refiners/training_utils/callback.py
+++ b/src/refiners/training_utils/callback.py
@@ -1,12 +1,80 @@
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from refiners.training_utils.common import (
+    Epoch,
+    Iteration,
+    Step,
+    TimeValue,
+    TimeValueInput,
+    parse_number_unit_field,
+    scoped_seed,
+)
 
 if TYPE_CHECKING:
-    from refiners.training_utils.config import BaseConfig
     from refiners.training_utils.trainer import Trainer
 
-T = TypeVar("T", bound="Trainer[BaseConfig, Any]")
+T = TypeVar("T", bound="Trainer[Any, Any]")
+
+
+class StepEventConfig(BaseModel):
+    """
+    Base configuration for an event that is triggered at every step.
+
+    - `seed`: Seed to use for the event. If `None`, the seed will not be set. The random state will be saved and
+    restored after the event.
+    - `interval`: Interval at which the event should be triggered. The interval is defined by either a `Step` object,
+    an `Iteration` object, or an `Epoch` object.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    seed: int | None = None
+    interval: Step | Iteration | Epoch = Step(1)
+
+    @field_validator("interval", mode="before")
+    def parse_field(cls, value: TimeValueInput) -> TimeValue:
+        return parse_number_unit_field(value)
+
+
+class IterationEventConfig(BaseModel):
+    """
+    Base configuration for an event that is triggered only once per iteration.
+
+    - `seed`: Seed to use for the event. If `None`, the seed will not be set. The random state will be saved and
+    restored after the event.
+    - `interval`: Interval at which the event should be triggered. The interval is defined by an `Iteration` object or
+    a `Epoch` object.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    seed: int | None = None
+    interval: Iteration | Epoch = Iteration(1)
+
+    @field_validator("interval", mode="before")
+    def parse_field(cls, value: TimeValueInput) -> TimeValue:
+        return parse_number_unit_field(value)
+
+
+class EpochEventConfig(BaseModel):
+    """
+    Base configuration for an event that is triggered only once per epoch.
+
+    - `seed`: Seed to use for the event. If `None`, the seed will not be set. The random state will be saved and
+    restored after the event.
+    - `interval`: Interval at which the event should be triggered. The interval is defined by a `Epoch` object.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    seed: int | None = None
+    interval: Epoch = Epoch(1)
+
+    @field_validator("interval", mode="before")
+    def parse_field(cls, value: TimeValueInput) -> TimeValue:
+        return parse_number_unit_field(value)
+
+
+EventConfig = StepEventConfig | IterationEventConfig | EpochEventConfig
 
 
 class CallbackConfig(BaseModel):
@@ -17,9 +85,37 @@ class CallbackConfig(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+    on_epoch_begin: EpochEventConfig = EpochEventConfig()
+    on_epoch_end: EpochEventConfig = EpochEventConfig()
+    on_batch_begin: StepEventConfig = StepEventConfig()
+    on_batch_end: StepEventConfig = StepEventConfig()
+    on_backward_begin: StepEventConfig = StepEventConfig()
+    on_backward_end: StepEventConfig = StepEventConfig()
+    on_optimizer_step_begin: IterationEventConfig = IterationEventConfig()
+    on_optimizer_step_end: IterationEventConfig = IterationEventConfig()
+    on_compute_loss_begin: StepEventConfig = StepEventConfig()
+    on_compute_loss_end: StepEventConfig = StepEventConfig()
+    on_evaluate_begin: IterationEventConfig = IterationEventConfig()
+    on_evaluate_end: IterationEventConfig = IterationEventConfig()
+    on_lr_scheduler_step_begin: IterationEventConfig = IterationEventConfig()
+    on_lr_scheduler_step_end: IterationEventConfig = IterationEventConfig()
 
 
 class Callback(Generic[T]):
+    def run_event(self, trainer: T, callback_name: str, event_name: str) -> None:
+        if not hasattr(self, event_name):
+            return
+        callback_config = getattr(trainer.config, callback_name)
+        # For event that run once, there is no configuration to check, e.g. on_train_begin
+        if not hasattr(callback_config, event_name):
+            getattr(self, event_name)(trainer)
+            return
+        event_config = cast(EventConfig, getattr(callback_config, event_name))
+        if not trainer.clock.is_due(event_config.interval):
+            return
+        with scoped_seed(event_config.seed):
+            getattr(self, event_name)(trainer)
+
     def on_init_begin(self, trainer: T) -> None: ...
 
     def on_init_end(self, trainer: T) -> None: ...

--- a/src/refiners/training_utils/clock.py
+++ b/src/refiners/training_utils/clock.py
@@ -89,6 +89,9 @@ class TrainingClock(Callback["Trainer[BaseConfig, Any]"]):
     def num_step_per_evaluation(self) -> int:
         return self.convert_time_value_to_steps(self.evaluation_interval)
 
+    def is_due(self, interval: TimeValue) -> bool:
+        return self.step % self.convert_time_value_to_steps(interval) == 0
+
     def reset(self) -> None:
         self.start_time = None
         self.end_time = None
@@ -109,29 +112,13 @@ class TrainingClock(Callback["Trainer[BaseConfig, Any]"]):
         assert self.start_time is not None, "Timer has not been started yet."
         return int(time.time() - self.start_time)
 
-    @cached_property
-    def evaluation_interval_steps(self) -> int:
-        return self.convert_time_value_to_steps(self.evaluation_interval)
-
-    @cached_property
-    def lr_scheduler_interval_steps(self) -> int:
-        return self.convert_time_value_to_steps(self.lr_scheduler_interval)
-
     @property
     def is_optimizer_step(self) -> bool:
         return self.num_minibatches_processed == self.num_step_per_iteration
 
     @property
-    def is_lr_scheduler_step(self) -> bool:
-        return self.step % self.lr_scheduler_interval_steps == 0
-
-    @property
     def done(self) -> bool:
         return self.step >= self.num_steps
-
-    @property
-    def is_evaluation_step(self) -> bool:
-        return self.step % self.evaluation_interval_steps == 0
 
     def log(self, message: str, /) -> None:
         if self.verbose:

--- a/src/refiners/training_utils/common.py
+++ b/src/refiners/training_utils/common.py
@@ -35,7 +35,6 @@ def human_readable_number(number: int) -> str:
 def seed_everything(seed: int | None = None) -> None:
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
-    logger.info(f"Using random seed: {seed}")
     random.seed(a=seed)
     np.random.seed(seed=seed)
     manual_seed(seed=seed)

--- a/tests/training_utils/mock_config.toml
+++ b/tests/training_utils/mock_config.toml
@@ -1,3 +1,12 @@
+[mock_callback.on_optimizer_step_begin]
+interval = "2:iteration"
+seed = 42
+
+
+[mock_callback.on_batch_end]
+interval = "3:step"
+
+
 [mock_model]
 requires_grad = true
 use_activation = true


### PR DESCRIPTION
### TL;DR
Added base configurations for events triggered at different intervals during training.

### What changed?
- Added `StepEventConfig`, `IterationEventConfig`, and `EpochEventConfig` base configurations for events triggered at different intervals.
- Added the possibility of scoping the random state of a callback trigger.
- Modified `CallbackConfig` to include configurations for various events.
- A method was added to `Callback` to run events based on configuration.

### How to test?
- Run `rye run pytest -k trainer`

---

