### PR TITLE
training_utils: export neptune config and mixin

### DIFF
--- a/src/refiners/training_utils/__init__.py
+++ b/src/refiners/training_utils/__init__.py
@@ -41,6 +41,7 @@ from refiners.training_utils.config import (
     Optimizers,
     TrainingConfig,
 )
+from refiners.training_utils.neptune import NeptuneConfig, NeptuneMixin
 from refiners.training_utils.trainer import Trainer, register_callback, register_model
 from refiners.training_utils.wandb import WandbConfig, WandbMixin
 
@@ -54,6 +55,8 @@ __all__ = [
     "CallbackConfig",
     "WandbMixin",
     "WandbConfig",
+    "NeptuneMixin",
+    "NeptuneConfig",
     "LRSchedulerConfig",
     "OptimizerConfig",
     "TrainingConfig",


### PR DESCRIPTION
Like W&B. With this, #371 would have broken `test_import_training_utils`.

Follow up of #371 and #372.