### PR TITLE
MultiUpscaler: specify map_location when loading negative embedding

### DIFF
--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/multi_upscaler.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_1/multi_upscaler.py
@@ -112,7 +112,9 @@ class MultiUpscalerAbstract(MultiDiffusion[T], ABC):
         if path is None:
             return ""
 
-        embeddings: Tensor | dict[str, Any] = torch.load(path, weights_only=True)  # type: ignore
+        embeddings: torch.Tensor | dict[str, Any] = torch.load(  # type: ignore
+            path, weights_only=True, map_location=self.device
+        )
 
         if isinstance(embeddings, dict):
             assert key is not None, "Key must be provided to access the negative embedding."


### PR DESCRIPTION
Forgot the `map_location=self.device`