### PR TITLE
Remove some `from torch import ...` from the code

### DIFF
--- a/src/refiners/fluxion/layers/chain.py
+++ b/src/refiners/fluxion/layers/chain.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from typing import Any, Callable, Iterable, Iterator, Sequence, TypeVar, cast, get_origin, overload
 
 import torch
-from torch import Tensor, cat, device as Device, dtype as DType
+from torch import Tensor, device as Device, dtype as DType
 
 from refiners.fluxion.context import ContextProvider, Contexts
 from refiners.fluxion.layers.module import ContextModule, Module, ModuleTree, WeightedModule
@@ -950,7 +950,7 @@ class Concatenate(Chain):
 
     def forward(self, *args: Any) -> Tensor:
         outputs = [module(*args) for module in self]
-        return cat(
+        return torch.cat(
             [output for output in outputs if output is not None],
             dim=self.dim,
         )

--- a/src/refiners/fluxion/layers/norm.py
+++ b/src/refiners/fluxion/layers/norm.py
@@ -1,5 +1,6 @@
+import torch
 from jaxtyping import Float
-from torch import Tensor, device as Device, dtype as DType, ones, sqrt, zeros
+from torch import Tensor, device as Device, dtype as DType
 from torch.nn import (
     GroupNorm as _GroupNorm,
     InstanceNorm2d as _InstanceNorm2d,
@@ -111,8 +112,8 @@ class LayerNorm2d(WeightedModule):
         dtype: DType | None = None,
     ) -> None:
         super().__init__()
-        self.weight = TorchParameter(ones(channels, device=device, dtype=dtype))
-        self.bias = TorchParameter(zeros(channels, device=device, dtype=dtype))
+        self.weight = TorchParameter(torch.ones(channels, device=device, dtype=dtype))
+        self.bias = TorchParameter(torch.zeros(channels, device=device, dtype=dtype))
         self.eps = eps
 
     def forward(
@@ -121,7 +122,7 @@ class LayerNorm2d(WeightedModule):
     ) -> Float[Tensor, "batch channels height width"]:
         x_mean = x.mean(1, keepdim=True)
         x_var = (x - x_mean).pow(2).mean(1, keepdim=True)
-        x_norm = (x - x_mean) / sqrt(x_var + self.eps)
+        x_norm = (x - x_mean) / torch.sqrt(x_var + self.eps)
         x_out = self.weight.unsqueeze(-1).unsqueeze(-1) * x_norm + self.bias.unsqueeze(-1).unsqueeze(-1)
         return x_out
 

--- a/src/refiners/fluxion/utils.py
+++ b/src/refiners/fluxion/utils.py
@@ -8,15 +8,7 @@ from numpy import array, float32
 from PIL import Image
 from safetensors import safe_open as _safe_open  # type: ignore
 from safetensors.torch import save_file as _save_file  # type: ignore
-from torch import (
-    Tensor,
-    cat,
-    device as Device,
-    dtype as DType,
-    manual_seed as _manual_seed,  # type: ignore
-    no_grad as _no_grad,  # type: ignore
-    norm as _norm,  # type: ignore
-)
+from torch import Tensor, device as Device, dtype as DType
 from torch.nn.functional import conv2d, interpolate as _interpolate, pad as _pad  # type: ignore
 
 T = TypeVar("T")
@@ -24,14 +16,14 @@ E = TypeVar("E")
 
 
 def norm(x: Tensor) -> Tensor:
-    return _norm(x)  # type: ignore
+    return torch.norm(x)  # type: ignore
 
 
 def manual_seed(seed: int) -> None:
-    _manual_seed(seed)
+    torch.manual_seed(seed)  # type: ignore
 
 
-class no_grad(_no_grad):
+class no_grad(torch.no_grad):
     def __new__(cls, orig_func: Any | None = None) -> "no_grad":  # type: ignore
         return object.__new__(cls)
 
@@ -123,7 +115,7 @@ def gaussian_blur(
 def images_to_tensor(
     images: list[Image.Image], device: Device | str | None = None, dtype: DType | None = None
 ) -> Tensor:
-    return cat([image_to_tensor(image, device=device, dtype=dtype) for image in images])
+    return torch.cat([image_to_tensor(image, device=device, dtype=dtype) for image in images])
 
 
 def image_to_tensor(image: Image.Image, device: Device | str | None = None, dtype: DType | None = None) -> Tensor:

--- a/src/refiners/foundationals/clip/common.py
+++ b/src/refiners/foundationals/clip/common.py
@@ -1,4 +1,5 @@
-from torch import Tensor, arange, device as Device, dtype as DType
+import torch
+from torch import Tensor, device as Device, dtype as DType
 
 import refiners.fluxion.layers as fl
 
@@ -25,7 +26,7 @@ class PositionalEncoder(fl.Chain):
 
     @property
     def position_ids(self) -> Tensor:
-        return arange(end=self.max_sequence_length, device=self.device).reshape(1, -1)
+        return torch.arange(end=self.max_sequence_length, device=self.device).reshape(1, -1)
 
     def get_position_ids(self, x: Tensor) -> Tensor:
         return self.position_ids[:, : x.shape[1]]

--- a/src/refiners/foundationals/latent_diffusion/range_adapter.py
+++ b/src/refiners/foundationals/latent_diffusion/range_adapter.py
@@ -1,7 +1,8 @@
 import math
 
+import torch
 from jaxtyping import Float, Int
-from torch import Tensor, arange, cat, cos, device as Device, dtype as DType, exp, float32, sin
+from torch import Tensor, device as Device, dtype as DType
 
 import refiners.fluxion.layers as fl
 from refiners.fluxion.adapters.adapter import Adapter
@@ -14,10 +15,10 @@ def compute_sinusoidal_embedding(
     half_dim = embedding_dim // 2
     # Note: it is important that this computation is done in float32.
     # The result can be cast to lower precision later if necessary.
-    exponent = -math.log(10000) * arange(start=0, end=half_dim, dtype=float32, device=x.device)
+    exponent = -math.log(10000) * torch.arange(start=0, end=half_dim, dtype=torch.float32, device=x.device)
     exponent /= half_dim
-    embedding = x.unsqueeze(1).float() * exp(exponent).unsqueeze(0)
-    embedding = cat([cos(embedding), sin(embedding)], dim=-1)
+    embedding = x.unsqueeze(1).float() * torch.exp(exponent).unsqueeze(0)
+    embedding = torch.cat([torch.cos(embedding), torch.sin(embedding)], dim=-1)
     return embedding
 
 

--- a/src/refiners/foundationals/latent_diffusion/solvers/ddim.py
+++ b/src/refiners/foundationals/latent_diffusion/solvers/ddim.py
@@ -1,6 +1,7 @@
 import dataclasses
 
-from torch import Generator, Tensor, device as Device, dtype as Dtype, float32, sqrt, tensor
+import torch
+from torch import Generator, Tensor, device as Device, dtype as Dtype
 
 from refiners.foundationals.latent_diffusion.solvers.solver import (
     BaseSolverParams,
@@ -28,7 +29,7 @@ class DDIM(Solver):
         first_inference_step: int = 0,
         params: BaseSolverParams | None = None,
         device: Device | str = "cpu",
-        dtype: Dtype = float32,
+        dtype: Dtype = torch.float32,
     ) -> None:
         """Initializes a new DDIM solver.
 
@@ -71,7 +72,7 @@ class DDIM(Solver):
             (
                 self.timesteps[step + 1]
                 if step < self.num_inference_steps - 1
-                else tensor(data=[0], device=self.device, dtype=self.dtype)
+                else torch.tensor(data=[0], device=self.device, dtype=self.dtype)
             ),
         )
         current_scale_factor, previous_scale_factor = (
@@ -82,8 +83,8 @@ class DDIM(Solver):
                 else self.cumulative_scale_factors[0]
             ),
         )
-        predicted_x = (x - sqrt(1 - current_scale_factor**2) * predicted_noise) / current_scale_factor
-        noise_factor = sqrt(1 - previous_scale_factor**2)
+        predicted_x = (x - torch.sqrt(1 - current_scale_factor**2) * predicted_noise) / current_scale_factor
+        noise_factor = torch.sqrt(1 - previous_scale_factor**2)
 
         # Do not add noise at the last step to avoid visual artifacts.
         if step == self.num_inference_steps - 1:

--- a/src/refiners/foundationals/latent_diffusion/solvers/dpm.py
+++ b/src/refiners/foundationals/latent_diffusion/solvers/dpm.py
@@ -3,7 +3,7 @@ from collections import deque
 
 import numpy as np
 import torch
-from torch import Generator, Tensor, device as Device, dtype as Dtype, float32, tensor
+from torch import Generator, Tensor, device as Device, dtype as Dtype
 
 from refiners.foundationals.latent_diffusion.solvers.solver import (
     BaseSolverParams,
@@ -38,7 +38,7 @@ class DPMSolver(Solver):
         params: BaseSolverParams | None = None,
         last_step_first_order: bool = False,
         device: Device | str = "cpu",
-        dtype: Dtype = float32,
+        dtype: Dtype = torch.float32,
     ):
         """Initializes a new DPM solver.
 
@@ -62,7 +62,7 @@ class DPMSolver(Solver):
             device=device,
             dtype=dtype,
         )
-        self.estimated_data = deque([tensor([])] * 2, maxlen=2)
+        self.estimated_data = deque([torch.tensor([])] * 2, maxlen=2)
         self.last_step_first_order = last_step_first_order
 
     def rebuild(
@@ -94,7 +94,7 @@ class DPMSolver(Solver):
         offset = self.params.timesteps_offset
         max_timestep = self.params.num_train_timesteps - 1 + offset
         np_space = np.linspace(offset, max_timestep, self.num_inference_steps + 1).round().astype(int)[1:]
-        return tensor(np_space).flip(0)
+        return torch.tensor(np_space).flip(0)
 
     def dpm_solver_first_order_update(
         self, x: Tensor, noise: Tensor, step: int, sde_noise: Tensor | None = None
@@ -110,7 +110,7 @@ class DPMSolver(Solver):
             The denoised version of the input data `x`.
         """
         current_timestep = self.timesteps[step]
-        previous_timestep = self.timesteps[step + 1] if step < self.num_inference_steps - 1 else tensor([0])
+        previous_timestep = self.timesteps[step + 1] if step < self.num_inference_steps - 1 else torch.tensor([0])
 
         previous_ratio = self.signal_to_noise_ratios[previous_timestep]
         current_ratio = self.signal_to_noise_ratios[current_timestep]
@@ -144,7 +144,7 @@ class DPMSolver(Solver):
         Returns:
             The denoised version of the input data `x`.
         """
-        previous_timestep = self.timesteps[step + 1] if step < self.num_inference_steps - 1 else tensor([0])
+        previous_timestep = self.timesteps[step + 1] if step < self.num_inference_steps - 1 else torch.tensor([0])
         current_timestep = self.timesteps[step]
         next_timestep = self.timesteps[step - 1]
 

--- a/src/refiners/foundationals/latent_diffusion/solvers/euler.py
+++ b/src/refiners/foundationals/latent_diffusion/solvers/euler.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from torch import Generator, Tensor, device as Device, dtype as Dtype, float32, tensor
+from torch import Generator, Tensor, device as Device, dtype as Dtype
 
 from refiners.foundationals.latent_diffusion.solvers.solver import (
     BaseSolverParams,
@@ -23,7 +23,7 @@ class Euler(Solver):
         first_inference_step: int = 0,
         params: BaseSolverParams | None = None,
         device: Device | str = "cpu",
-        dtype: Dtype = float32,
+        dtype: Dtype = torch.float32,
     ):
         """Initializes a new Euler solver.
 
@@ -57,7 +57,7 @@ class Euler(Solver):
         """Generate the sigmas used by the solver."""
         sigmas = self.noise_std / self.cumulative_scale_factors
         sigmas = torch.tensor(np.interp(self.timesteps.cpu(), np.arange(0, len(sigmas)), sigmas.cpu()))
-        sigmas = torch.cat([sigmas, tensor([0.0])])
+        sigmas = torch.cat([sigmas, torch.tensor([0.0])])
         return sigmas.to(device=self.device, dtype=self.dtype)
 
     def scale_model_input(self, x: Tensor, step: int) -> Tensor:

--- a/src/refiners/foundationals/latent_diffusion/solvers/franken.py
+++ b/src/refiners/foundationals/latent_diffusion/solvers/franken.py
@@ -1,7 +1,8 @@
 import dataclasses
 from typing import Any, Callable, Protocol, TypeVar
 
-from torch import Generator, Tensor, device as Device, dtype as DType, float32
+import torch
+from torch import Generator, Tensor, device as Device, dtype as DType
 
 from refiners.foundationals.latent_diffusion.solvers.solver import Solver, TimestepSpacing
 
@@ -60,7 +61,7 @@ class FrankenSolver(Solver):
         num_inference_steps: int,
         first_inference_step: int = 0,
         device: Device | str = "cpu",
-        dtype: DType = float32,
+        dtype: DType = torch.float32,
         **kwargs: Any,  # for typing, ignored
     ) -> None:
         self.get_diffusers_scheduler = get_diffusers_scheduler

--- a/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/text_encoder.py
+++ b/src/refiners/foundationals/latent_diffusion/stable_diffusion_xl/text_encoder.py
@@ -1,7 +1,8 @@
 from typing import cast
 
+import torch
 from jaxtyping import Float
-from torch import Tensor, cat, device as Device, dtype as DType, split
+from torch import Tensor, cat, device as Device, dtype as DType
 
 import refiners.fluxion.layers as fl
 from refiners.fluxion.adapters.adapter import Adapter
@@ -48,7 +49,7 @@ class TextEncoderWithPooling(fl.Chain, Adapter[CLIPTextEncoderG]):
         return self.ensure_find(CLIPTokenizer)
 
     def set_end_of_text_index(self, end_of_text_index: list[int], tokens: Tensor) -> None:
-        for str_tokens in split(tokens, 1):
+        for str_tokens in torch.split(tokens, 1):
             position = (str_tokens == self.tokenizer.end_of_text_token_id).nonzero(as_tuple=True)[1].item()  # type: ignore
             end_of_text_index.append(cast(int, position))
 


### PR DESCRIPTION
See https://huggingface.co/spaces/zero-gpu-explorers/README/discussions/85
I also find it better to have the `torch.` prefix

I ran all the tests just in case (with `torch<2.4.0`), everything is good (~~I fixed the ic-light test, it got broken in a previous commit because we switched a default~~ -> https://github.com/finegrain-ai/refiners/pull/403)
