### PR TITLE
comfyui-refiners fix requirements.txt

### DIFF
--- a/src/comfyui-refiners/pyproject.toml
+++ b/src/comfyui-refiners/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-refiners"
 description = "ComfyUI custom nodes for refiners models"
-version = "1.0.2"
+version = "1.0.3"
 license = { file = "LICENSE" }
 dependencies = [
     "refiners @ git+https://github.com/finegrain-ai/refiners.git",

--- a/src/comfyui-refiners/requirements.txt
+++ b/src/comfyui-refiners/requirements.txt
@@ -1,1 +1,3 @@
--e file:.
+git+https://github.com/finegrain-ai/refiners.git
+huggingface_hub
+transformers


### PR DESCRIPTION
Well it looks like #423 doesn't work:
```
comfy node registry-install comfyui-manager
...
CalledProcessError: Command '['/home/laurent/github.com/comfyanonymous/ComfyUI/.venv2/bin/python3.12', '-m', 'pip', 'install', '-e file:.']' returned non-zero exit status 1.
```

I think this is because they basically do
```bash
cat requirements.txt | xargs -i pip install {}
```
and because `-e file:.` is obviously an incorrect argument (it should be split in two).

Anyway, let's hardcode the actual deps into the requirements.txt and pray that they will also support using the deps directly inside the pyproject.toml in the future.