### PR TITLE
Make MultiDiffusion work with a Generator

### DIFF
--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -2669,7 +2669,9 @@ def test_multi_upscaler(
     clarity_example: Image.Image,
     expected_multi_upscaler: Image.Image,
 ) -> None:
-    predicted_image = multi_upscaler.upscale(clarity_example)
+    generator = torch.Generator(device=multi_upscaler.device)
+    generator.manual_seed(37)
+    predicted_image = multi_upscaler.upscale(clarity_example, generator=generator)
     ensure_similar_images(predicted_image, expected_multi_upscaler, min_psnr=35, min_ssim=0.99)
 
 


### PR DESCRIPTION
- made `MultiUpscaler.diffuse_targets` "stateless" (i.e. it doesn't call `torch.randn` to sample `noise`)
- added a generator argument to `MultiUpscaler.upscale`, and use it when sampling the `noise` argument used in `MultiUpscaler.diffuse_targets`
- modified `test_multi_upscaler` accordingly