### PR TITLE
Removed `compute_clip_image_embedding` overloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ black = true
 [tool.pyright]
 include = ["src/refiners", "tests", "scripts"]
 strict = ["*"]
-exclude = ["**/__pycache__", "tests/weights"]
+exclude = ["**/__pycache__", "tests/weights", "tests/repos"]
 reportMissingTypeStubs = "warning"
 
 [tool.coverage.run]


### PR DESCRIPTION
The `compute_clip_image_embedding` overloads don't seem to have a purpose, I removed them and tweaked the main docstring a bit.
I also added "tests/repos" to the pyright exclusion.