### PR TITLE
fix `CLIPTokenizer` skipping underscores

### DIFF
--- a/src/refiners/foundationals/clip/tokenizer.py
+++ b/src/refiners/foundationals/clip/tokenizer.py
@@ -44,7 +44,7 @@ class CLIPTokenizer(fl.Module):
         # to get rid of the dependence on the `regex` module. Unicode support could
         # potentially be added back by leveraging the `\w` character class.
         self.token_pattern = re.compile(
-            pattern=r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[a-zA-Z]+|[0-9]|[^\s\w]+""",
+            pattern=r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[a-zA-Z]+|[0-9]|(?:[^\s\w]|_)+""",
             flags=re.IGNORECASE,
         )
         self.start_of_text_token_id: int = start_of_text_token_id


### PR DESCRIPTION
The current `CLIPTokenizer` regex uses `[^\s\w]+`, which causes it to skip underscores since `\w` matches them. Checking the bundled vocab, it seems underscores are only ever part of a word that has no alphanumerics (aside from a couple mojibaked words), so the underscore fits in with the `[^\s\w]+` part.

Changing `[^\s\w]+` to `(?:[^\s\w]|_)+` allows tokenizing underscores, which should better match other tokenizer implementations.