### PR TITLE
Check for conversion deps when using `refiners.conversion`

### DIFF
--- a/src/refiners/conversion/__init__.py
+++ b/src/refiners/conversion/__init__.py
@@ -1,3 +1,36 @@
+import sys
+from importlib import import_module
+from importlib.metadata import requires
+
+from packaging.requirements import Requirement
+
+refiners_requires = requires("refiners")
+assert refiners_requires is not None
+
+# Some dependencies have different module names than their package names
+req_to_module: dict[str, str] = {
+    "huggingface-hub": "huggingface_hub",
+    "segment-anything-py": "segment_anything",
+}
+
+for dep in refiners_requires:
+    req = Requirement(dep)
+    marker = req.marker
+    if marker is None or not marker.evaluate({"extra": "conversion"}):
+        continue
+
+    module_name = req_to_module.get(req.name, req.name)
+
+    try:
+        import_module(module_name)
+    except ImportError:
+        print(
+            f"Some dependencies are missing: {req.name}. "
+            "Please install refiners with the `conversion` extra, e.g. `pip install refiners[conversion]`",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
 from .models import (
     autoencoder_sd15,
     autoencoder_sdxl,


### PR DESCRIPTION
small test snippet:
```shell
cd /tmp
python3 -m venv .venv
. .venv/bin/activate

pip install refiners@git+https://github.com/finegrain-ai/refiners@pr/check_refiners_conversion_deps
python -c 'import refiners.conversion' # should fail, with message: Some dependencies are missing: ... Please install refiners with the `conversion` extra, e.g. `pip install refiners[conversion]`
pip install refiners[conversion]@git+https://github.com/finegrain-ai/refiners@pr/check_refiners_conversion_deps
python -c 'import refiners.conversion' # should work
```