### PR TITLE
make `refiners.conversion.utils.Hub.expected_sha256` optional

### DIFF
--- a/src/refiners/foundationals/segment_anything/model.py
+++ b/src/refiners/foundationals/segment_anything/model.py
@@ -80,7 +80,7 @@ class SegmentAnything(fl.Chain):
 
     @no_grad()
     def compute_image_embedding(self, image: Image.Image) -> ImageEmbedding:
-        """Compute the emmbedding of an image.
+        """Compute the embedding of an image.
 
         Args:
             image: The image to compute the embedding of.

--- a/src/refiners/foundationals/swin/swin_transformer.py
+++ b/src/refiners/foundationals/swin/swin_transformer.py
@@ -205,7 +205,7 @@ class WindowSDPA(fl.Module):
 
 class WindowAttention(fl.Chain):
     """
-    Window-based Multi-head Self-Attenion (W-MSA), optionally shifted (SW-MSA).
+    Window-based Multi-head Self-Attention (W-MSA), optionally shifted (SW-MSA).
 
     It has a trainable relative position bias (RelativePositionBias).
 

--- a/tests/weight_paths.py
+++ b/tests/weight_paths.py
@@ -31,7 +31,7 @@ def get_path(hub: Hub, use_local_weights: bool) -> Path:
     if use_local_weights:
         path = hub.local_path
     else:
-        if hub.override_download_url is not None:
+        if hub.download_url is not None:
             pytest.skip(f"{hub.filename} is not available on Hugging Face Hub")
 
         try:


### PR DESCRIPTION
This way you can use a `Hub` object without specifying the hash, useful when declaring where to find a weight on the hub (since there is no need to check the hash).